### PR TITLE
[codex] write product brief and target learner assumptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # FNE
-FNE stands for Friday Night English, and aims to be a rhythm-based learning game.
+FNE stands for Friday Night English.
+
+## Product Brief
+FNE is a rhythm-based vocabulary learning game for junior-high students who struggle with text-only study. It borrows the energy and clear feedback loop of Friday Night Funkin' so practice feels like play instead of a worksheet.
+
+### Target Learner Assumptions
+- The learner is in junior high and already knows some English words, but loses them when study depends on reading definitions.
+- The learner responds better to fast, visual cues than to dense text explanations.
+- The learner is more likely to repeat practice when the activity feels like timing, performance, and progression.
+
+### Motivation Problem
+Text-first flashcards force the learner to decode meaning from words before they can remember it. That adds friction, lowers confidence, and makes repetition feel like homework.
+
+### Core Retention Strategy
+Each word is taught through an image plus pronunciation. The image gives immediate meaning, and the spoken form anchors the word in memory through sound. Using both together reduces dependence on text and gives the learner two cues to recall later.
+
+### Learning Goal
+Help the learner recognize and remember common English vocabulary through short, repeatable rhythm rounds.
+
+### First-Wave Success Criteria
+- The learner understands the intended word from the image and pronunciation without needing a long text explanation.
+- The learner can complete a short rhythm round and wants to try another one.
+- In early playtests, the learner can recall or recognize the word shortly after practice.
+- The experience feels like a motivating game loop first, and a study tool second.

--- a/scripts/check-product-brief.sh
+++ b/scripts/check-product-brief.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
 set -eu
 
-file="README.md"
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+file="$script_dir/../README.md"
 
 check() {
   pattern="$1"

--- a/scripts/check-product-brief.sh
+++ b/scripts/check-product-brief.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+file="README.md"
+
+check() {
+  pattern="$1"
+  if ! grep -Fq "$pattern" "$file"; then
+    printf 'missing required brief content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check "Product Brief"
+check "Target Learner Assumptions"
+check "Motivation Problem"
+check "Core Retention Strategy"
+check "Learning Goal"
+check "First-Wave Success Criteria"
+check "junior-high"
+check "Friday Night Funkin"
+check "image plus pronunciation"
+
+printf 'product brief check passed\n'


### PR DESCRIPTION
## What changed
- Expanded the root `README.md` into a standalone product brief for FNE.
- Documented the target learner assumptions, the motivation problem, the core retention strategy, the learning goal, and first-wave success criteria.
- Added `scripts/check-product-brief.sh` to verify the brief contains the required concepts.

## Why
- Issue #2 needs a concise brief that can stand alone without chat history.
- The repo started with a two-line README, so the brief was not yet explicit.

## Validation
- Ran `sh scripts/check-product-brief.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified product description, naming it "Friday Night English" and framing it as a rhythm-based vocabulary game
  * Added learner profile, motivation problem, retention strategy, and pronunciation/image notes
  * Defined first-wave success criteria as explicit bullet points

* **Chores**
  * Added a validation script to enforce required product-brief content and report missing sections
<!-- end of auto-generated comment: release notes by coderabbit.ai -->