### PR TITLE
Epic 1.2 - Write architecture decision record for browser-first stack

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,7 @@ They would increase distribution and maintenance cost without improving the core
 This split keeps the UI layer separate from the gameplay loop and keeps audio explicit instead of hidden inside a general-purpose engine abstraction.
 
 ## TypeScript posture
-The codebase should stay on current stable TypeScript while remaining easy to move to TypeScript 7 and later.
+The codebase should stay on current stable TypeScript while remaining easy to move to future TypeScript versions.
 
 Practical rules:
 
@@ -73,4 +73,3 @@ This decision is considered valid if a browser-only PoC can cover the first game
 - a Phaser gameplay scene
 - at least one audio cue through Howler.js
 - installable or cacheable PWA behavior
-

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,76 @@
+# Architecture Decision Record: Browser-First Stack
+
+## Status
+Accepted
+
+## Context
+FNE is a rhythm-based vocabulary game for junior-high students. The first version needs to prove the core learning loop quickly, with the lowest possible setup friction for both development and playtesting.
+
+The product will start as a browser app instead of a heavier game-engine or native-client stack. That choice keeps the PoC easy to open, share, and iterate on during early validation.
+
+## Decision
+Build the first release with:
+
+- TypeScript for application and gameplay code
+- React for menus, onboarding, settings, and other UI around the game loop
+- Vite for local development, bundling, and fast rebuilds
+- Phaser for the 2D gameplay scene and timing-driven interactions
+- Howler.js for audio playback and sound control
+- PWA support for installability and offline-friendly caching
+
+## Why browser-first
+Browser-first development is the right baseline for this project because it reduces friction in the exact places that matter during early validation:
+
+- No install-heavy runtime is needed to try the game.
+- Playtests can happen through a link on common school and personal devices.
+- Iteration is fast because UI, game logic, and asset changes can be previewed in the browser immediately.
+- The stack stays close to standard web capabilities, which makes it easier to recruit help, debug issues, and ship small improvements.
+- PWA support gives us an upgrade path toward app-like behavior without committing to a native wrapper too early.
+
+## Rejected alternatives
+
+### Heavier game engines
+Unity, Unreal, and similar engine-first approaches were rejected for the initial baseline.
+
+They are optimized for larger production teams and more complex 3D or cross-platform native packaging needs. For FNE, they would add runtime weight, editor overhead, and a slower iteration loop before the core learning loop has been proven.
+
+### Native-first app development
+Native mobile or desktop clients were also rejected for the first pass.
+
+They would increase distribution and maintenance cost without improving the core proof-of-concept: a short, browser-delivered rhythm lesson with audio feedback and visual prompts.
+
+## Role split
+
+- React owns chrome and orchestration around the game, including screens, prompts, progress, and settings.
+- Phaser owns the moment-to-moment gameplay scene, timing windows, note flow, and hit detection.
+- Howler.js owns sound playback, voice cues, timing-safe audio triggers, and basic volume control.
+- Vite owns the dev server and production build pipeline.
+- PWA support owns installability, caching, and the ability to revisit the game with less friction.
+
+This split keeps the UI layer separate from the gameplay loop and keeps audio explicit instead of hidden inside a general-purpose engine abstraction.
+
+## TypeScript posture
+The codebase should stay on current stable TypeScript while remaining easy to move to TypeScript 7 and later.
+
+Practical rules:
+
+- Keep compiler usage modern and avoid leaning on deprecated or legacy-only flags.
+- Prefer explicit public interfaces at React and game boundaries.
+- Keep engine-specific code behind small adapters so a future TypeScript upgrade only touches a narrow surface area.
+- Treat the compiler as a compatibility signal and update it incrementally, not in large jumps.
+
+## Consequences
+
+- The team can ship a browser-first PoC quickly.
+- The architecture stays understandable to contributors who know web development.
+- The first release remains focused on proving the learning loop instead of building a general game platform.
+- If the product later needs a heavier engine or a native wrapper, that can be introduced after the browser proof has been validated.
+
+## Validation
+This decision is considered valid if a browser-only PoC can cover the first game loop with:
+
+- a React UI shell
+- a Phaser gameplay scene
+- at least one audio cue through Howler.js
+- installable or cacheable PWA behavior
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@
 Accepted
 
 ## Context
-FNE is a rhythm-based vocabulary game for junior-high students. The first version needs to prove the core learning loop quickly, with the lowest possible setup friction for both development and playtesting.
+FNE is a rhythm-based vocabulary game for junior high school students. The first version needs to prove the core learning loop quickly, with the lowest possible setup friction for both development and playtesting.
 
 The product will start as a browser app instead of a heavier game-engine or native-client stack. That choice keeps the PoC easy to open, share, and iterate on during early validation.
 

--- a/scripts/check-architecture-adr.sh
+++ b/scripts/check-architecture-adr.sh
@@ -26,7 +26,7 @@ check "Native-first app development"
 check "React owns"
 check "Phaser owns"
 check "Howler.js owns"
-check "TypeScript 7"
+check "future TypeScript versions"
 check "browser-only PoC"
 
 printf 'architecture ADR check passed\n'

--- a/scripts/check-architecture-adr.sh
+++ b/scripts/check-architecture-adr.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+file="$script_dir/../docs/architecture.md"
+
+check() {
+  pattern="$1"
+  if ! grep -Fq "$pattern" "$file"; then
+    printf 'missing required architecture ADR content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check "Browser-First Stack"
+check "Accepted"
+check "TypeScript"
+check "React"
+check "Vite"
+check "Phaser"
+check "Howler.js"
+check "PWA"
+check "Unity"
+check "Unreal"
+check "Native-first app development"
+check "React owns"
+check "Phaser owns"
+check "Howler.js owns"
+check "TypeScript 7"
+check "browser-only PoC"
+
+printf 'architecture ADR check passed\n'


### PR DESCRIPTION
Adds the browser-first architecture decision record and a focused validation script.

Validation:
- ./scripts/check-architecture-adr.sh

Notes:
- Documents why the first release starts as a web app
- Names the rejected heavier-engine and native-first alternatives
- Describes the split between React, Phaser, Howler.js, Vite, and PWA
- States a TypeScript 7-friendly upgrade posture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an Architecture Decision Record documenting the chosen browser-first technology stack, design rationale, constraints, and validation criteria for the project.
* **Chores**
  * Added an executable check to validate required ADR content as part of the project workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->