### PR TITLE
Define planning glossary

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ FNE stands for Friday Night English.
 
 ## Repository Layout
 The initial monorepo shape is documented in [docs/repo-boundaries.md](docs/repo-boundaries.md).
+The planning glossary for shared issue vocabulary lives in [docs/planning-glossary.md](docs/planning-glossary.md).
 
 ## Product Brief
 FNE is a rhythm-based vocabulary learning game for junior-high students who struggle with text-only study. It borrows the energy and clear feedback loop of Friday Night Funkin' so practice feels like play instead of a worksheet.

--- a/docs/planning-glossary.md
+++ b/docs/planning-glossary.md
@@ -1,0 +1,66 @@
+# Planning Glossary
+
+## Purpose
+Use these terms consistently in planning docs, issues, and implementation tickets so future work can reuse the same language without interpretation drift.
+
+## Content Terms
+
+### Pack
+A pack is the content bundle that ships as one unit.
+
+A pack groups the vocabulary, assets, and pack-level metadata needed for a lesson set. Runtime code should treat the pack as the top-level content boundary and load it through the manifest or loader defined in the repository layout.
+
+Use `pack` when referring to the reusable content package itself. Do not replace it with `course`, `unit`, or `book`.
+
+### Stage
+A stage is a playable slice inside a pack.
+
+A stage groups a small set of words or objectives into one progression step so the learner can complete a short lesson before moving on. A stage belongs to a pack and should read as a content progression concept, not as a generic engine scene.
+
+Use `stage` when referring to a lesson-sized progression step. Do not replace it with `level`, `chapter`, or `round`.
+
+### Mode
+A mode is the rule set or presentation profile used to run a stage.
+
+Modes let the product vary how a stage behaves without changing the underlying pack content. Example differences may include a practice-focused flow, a review-focused flow, or a stricter timing profile.
+
+Use `mode` when referring to a gameplay configuration. Do not replace it with `difficulty` unless the issue is specifically about challenge tuning.
+
+## Gameplay Terms
+
+### Weak Word
+A weak word is a word the learner has not yet secured and needs more repetition on.
+
+Weak words are promoted by performance or recall signals so the review system can surface them again. The term is about learner state, not about the word itself being poor quality.
+
+Use `weak word` when referring to a target for extra practice. Do not replace it with `missed word`, `forgotten word`, or `error word`.
+
+### Review Loop
+The review loop is the repeat cycle that brings weak words back into practice.
+
+It is the product mechanism for spacing repetition, rechecking recall, and giving the learner another chance to recognize or pronounce the word. The review loop should stay short and motivating so it feels like part of the rhythm game instead of a separate quiz mode.
+
+Use `review loop` when referring to the recurring practice cycle. Do not replace it with `retry loop` or `study loop`.
+
+### Hit Window
+The hit window is the timing range in which an input counts as a successful hit.
+
+This term belongs to the rhythm layer and describes the tolerance around the expected beat or cue timing. It should stay separate from content language because it is about input judgment, not vocabulary mastery.
+
+Use `hit window` when referring to timing tolerance. Do not replace it with `timing window` or `accuracy band`.
+
+## Usage Rules
+
+- Use `pack` for content bundles, `stage` for progression slices, and `mode` for gameplay rulesets.
+- Use `weak word` and `review loop` for learner recovery and repetition concepts.
+- Use `hit window` only for timing tolerance in gameplay.
+- If a later issue needs a new term, define it here before using it in implementation tickets.
+
+## Completeness Check
+The glossary is complete enough for the current planning phase when it covers:
+
+- content organization through `pack` and `stage`
+- gameplay configuration through `mode`
+- learner recovery through `weak word` and `review loop`
+- rhythm timing through `hit window`
+

--- a/scripts/check-planning-glossary.sh
+++ b/scripts/check-planning-glossary.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+doc="$script_dir/../docs/planning-glossary.md"
+readme="$script_dir/../README.md"
+
+check_doc() {
+  pattern="$1"
+  if ! grep -Fq "$pattern" "$doc"; then
+    printf 'missing required glossary content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_readme() {
+  pattern="$1"
+  if ! grep -Fq "$pattern" "$readme"; then
+    printf 'missing README glossary pointer: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_doc "Planning Glossary"
+check_doc "## Content Terms"
+check_doc "## Gameplay Terms"
+check_doc "Pack"
+check_doc "Stage"
+check_doc "Mode"
+check_doc "Weak Word"
+check_doc "Review Loop"
+check_doc "Hit Window"
+check_doc "content bundle that ships as one unit"
+check_doc "playable slice inside a pack"
+check_doc "rule set or presentation profile"
+check_doc "word the learner has not yet secured"
+check_doc "repeat cycle that brings weak words back into practice"
+check_doc "timing range in which an input counts as a successful hit"
+check_readme "docs/planning-glossary.md"
+
+printf 'planning glossary check passed\n'


### PR DESCRIPTION
Draft PR for issue #5.\n\nSummary:\n- Adds a canonical planning glossary for pack, stage, mode, weak word, review loop, and hit window\n- Links the glossary from README.md\n- Adds a focused shell check to keep the terminology stable\n\nVerification:\n- ./scripts/check-planning-glossary.sh\n- ./scripts/check-product-brief.sh\n- ./scripts/check-architecture-adr.sh\n- ./scripts/check-repo-boundaries.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added planning glossary defining key terminology: pack, stage, mode for content progression, and weak word, review loop, hit window for gameplay and learning concepts
  * Updated README to reference the planning glossary

* **Chores**
  * Added automated validation script to ensure glossary completeness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->