### PR TITLE
Add TypeScript review checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The initial monorepo shape is documented in [docs/repo-boundaries.md](docs/repo-
 The planning glossary for shared issue vocabulary lives in [docs/planning-glossary.md](docs/planning-glossary.md).
 The TypeScript usage policy lives in [docs/typescript-policy.md](docs/typescript-policy.md).
 The draft TypeScript compiler baseline lives in [docs/typescript-baseline.md](docs/typescript-baseline.md).
+The TypeScript compatibility review checklist lives in [docs/typescript-review-checklist.md](docs/typescript-review-checklist.md).
 
 ## Product Brief
 FNE is a rhythm-based vocabulary learning game for junior-high students who struggle with text-only study. It borrows the energy and clear feedback loop of Friday Night Funkin' so practice feels like play instead of a worksheet.

--- a/docs/typescript-policy.md
+++ b/docs/typescript-policy.md
@@ -32,4 +32,4 @@ Write code so a future TypeScript 7 upgrade is mostly a config update, not a rew
 
 ## Review Rule
 
-If a change introduces a new module shape, import path, or compiler setting, the review should check it against this policy before approval.
+If a change introduces a new module shape, import path, compiler setting, or asset-loading path, the review should check it against this policy and the [TypeScript Compatibility Review Checklist](docs/typescript-review-checklist.md) before approval.

--- a/docs/typescript-policy.md
+++ b/docs/typescript-policy.md
@@ -32,4 +32,4 @@ Write code so a future TypeScript 7 upgrade is mostly a config update, not a rew
 
 ## Review Rule
 
-If a change introduces a new module shape, import path, compiler setting, or asset-loading path, the review should check it against this policy and the [TypeScript Compatibility Review Checklist](docs/typescript-review-checklist.md) before approval.
+If a change introduces a new module shape, import path, compiler setting, or asset-loading path, the review should check it against this policy and the [TypeScript Compatibility Review Checklist](./typescript-review-checklist.md) before approval.

--- a/docs/typescript-review-checklist.md
+++ b/docs/typescript-review-checklist.md
@@ -1,0 +1,44 @@
+# TypeScript Compatibility Review Checklist
+
+Use this checklist before approving changes that touch TypeScript modules, imports, configuration, or asset loading.
+
+## Module Shape
+
+- [ ] The change keeps the codebase on ES modules only.
+- [ ] No CommonJS syntax was introduced (`require`, `module.exports`, `export =`, or `import = require`).
+- [ ] No legacy TypeScript namespaces or `const enum` usage was added.
+- [ ] Any new module boundary stays compatible with the browser-first stack.
+
+## Import Hygiene
+
+- [ ] Imports stay within the package through relative paths.
+- [ ] Cross-package imports use a package entrypoint or documented public adapter.
+- [ ] No deep import reaches into another package's private `src/` files.
+- [ ] Browser-facing code does not pick up Node-only assumptions through imports.
+
+## Config Hygiene
+
+- [ ] The change does not weaken strict TypeScript settings.
+- [ ] New `tsconfig` settings stay aligned with the modern baseline.
+- [ ] No deprecated or legacy compiler flag was added.
+- [ ] Any exception is documented next to the override so it can be revisited.
+
+## Asset Loading Hygiene
+
+- [ ] Asset loading goes through a typed loader or manifest boundary.
+- [ ] Raw string paths are not spread through gameplay code without a clear adapter.
+- [ ] Asset access stays compatible with the browser-first runtime.
+- [ ] New asset-loading code does not hide type errors behind dynamic lookup.
+
+## Typing Hygiene
+
+- [ ] Public boundaries use explicit types instead of inferred spillover.
+- [ ] No `any` was introduced unless it is isolated at an external boundary and justified.
+- [ ] `@ts-ignore` and `@ts-nocheck` were not added.
+- [ ] Type problems were fixed locally rather than by widening types globally.
+
+## Review Closeout
+
+- [ ] The diff still looks easy to upgrade with future TypeScript releases.
+- [ ] Any exception is narrow, documented, and obviously temporary.
+- [ ] The checklist was applied without ambiguity to the changed files.

--- a/scripts/check-typescript-review-checklist.sh
+++ b/scripts/check-typescript-review-checklist.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+file="$script_dir/../docs/typescript-review-checklist.md"
+
+if [ ! -f "$file" ]; then
+  printf 'missing TypeScript review checklist doc: %s\n' "$file" >&2
+  exit 1
+fi
+
+check_present() {
+  pattern="$1"
+  if ! grep -Fq "$pattern" "$file"; then
+    printf 'missing required TypeScript review checklist content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_present "TypeScript Compatibility Review Checklist"
+check_present "Module Shape"
+check_present "Import Hygiene"
+check_present "Config Hygiene"
+check_present "Asset Loading Hygiene"
+check_present "Typing Hygiene"
+check_present "ES modules only"
+check_present "strict TypeScript settings"
+check_present 'No `any`'
+check_present "typed loader or manifest"
+
+printf 'TypeScript review checklist check passed\n'


### PR DESCRIPTION
Adds a concise TypeScript compatibility review checklist and links it from the TS policy and README.\n\nVerification:\n- sh scripts/check-typescript-review-checklist.sh\n- sh scripts/check-typescript-policy.sh\n- sh scripts/check-typescript-baseline.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive TypeScript compatibility review checklist covering module shape, import hygiene, configuration standards, asset loading, typing expectations, and review closeout.
  * Updated the TypeScript policy to require checking changes against the new checklist before approval.

* **Chores**
  * Added a validation script to verify the checklist exists and contains required items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->