### PR TITLE
[codex] define canonical vocabulary item schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ FNE stands for Friday Night English.
 ## Repository Layout
 The initial monorepo shape is documented in [docs/repo-boundaries.md](docs/repo-boundaries.md).
 The planning glossary for shared issue vocabulary lives in [docs/planning-glossary.md](docs/planning-glossary.md).
+The canonical vocabulary item schema lives in [docs/vocabulary-item-schema.md](docs/vocabulary-item-schema.md).
 The TypeScript usage policy lives in [docs/typescript-policy.md](docs/typescript-policy.md).
 The draft TypeScript compiler baseline lives in [docs/typescript-baseline.md](docs/typescript-baseline.md).
 The TypeScript compatibility review checklist lives in [docs/typescript-review-checklist.md](docs/typescript-review-checklist.md).

--- a/docs/vocabulary-item-schema.md
+++ b/docs/vocabulary-item-schema.md
@@ -1,0 +1,57 @@
+# Vocabulary Item Schema
+
+## Status
+Proposed
+
+## Purpose
+Define the canonical JSON schema for one vocabulary item so pack docs and asset docs can reuse the same item shape without introducing pack-level assumptions.
+
+## Canonical Shape
+
+```json
+{
+  "id": "apple",
+  "term": "apple",
+  "meaning": "りんご",
+  "pronunciation": "AP-uhl",
+  "imageAssetId": "img-apple",
+  "audioAssetId": "aud-apple",
+  "exampleSentence": "I eat an apple.",
+  "partOfSpeech": "noun",
+  "tags": ["fruit", "food"],
+  "notes": "Common beginner vocabulary."
+}
+```
+
+## Required Fields
+
+- `id`: Stable item identifier string.
+- `term`: The vocabulary item shown to the learner.
+- `meaning`: The short meaning or translation used to describe the item.
+- `pronunciation`: A learner-facing pronunciation hint, such as a simple phonetic guide or IPA-like string.
+- `imageAssetId`: Opaque reference to the image asset for the item.
+- `audioAssetId`: Opaque reference to the pronunciation audio asset for the item.
+
+## Optional Fields
+
+- `exampleSentence`: A short example sentence for later study or review screens.
+- `partOfSpeech`: A compact grammatical label such as `noun` or `verb`.
+- `tags`: An array of descriptive strings used for grouping or filtering.
+- `notes`: Additional editorial notes that do not change the learning content.
+
+## Validation Behavior
+
+- Reject the item if any required field is missing.
+- Reject the item if any required field is present but not a string.
+- Reject the item if any required string field is blank or contains only whitespace.
+- Reject the item if `tags` is present but is not an array of non-empty strings.
+- Reject the item if `exampleSentence`, `partOfSpeech`, or `notes` are present but are not strings.
+- Treat `imageAssetId` and `audioAssetId` as opaque identifiers at this layer; asset existence is validated separately by asset or pack validation.
+- Unknown fields are rejected so the schema stays stable and predictable.
+
+## Reusability
+
+- This schema describes one item only and does not depend on pack id, stage id, or pack ordering.
+- Pack docs can reference this schema for vocabulary content.
+- Asset docs can reference this schema for the shape of asset-backed item fields.
+- If the schema needs new fields later, add them here first and update every dependent doc together.

--- a/scripts/check-vocabulary-item-schema.sh
+++ b/scripts/check-vocabulary-item-schema.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+doc="$script_dir/../docs/vocabulary-item-schema.md"
+readme="$script_dir/../README.md"
+
+check_doc() {
+  pattern="$1"
+  if ! grep -Fq "$pattern" "$doc"; then
+    printf 'missing required vocabulary schema content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_readme() {
+  pattern="$1"
+  if ! grep -Fq "$pattern" "$readme"; then
+    printf 'missing README vocabulary-schema pointer: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_doc "Vocabulary Item Schema"
+check_doc "canonical JSON schema"
+check_doc "Required Fields"
+check_doc "Optional Fields"
+check_doc "Validation Behavior"
+check_doc "Reusability"
+check_doc "id"
+check_doc "term"
+check_doc "meaning"
+check_doc "imageAssetId"
+check_doc "audioAssetId"
+check_doc "Unknown fields are rejected"
+check_doc "Reject the item if any required field is missing."
+check_readme "docs/vocabulary-item-schema.md"
+
+printf 'vocabulary item schema check passed\n'

--- a/scripts/check-vocabulary-item-schema.sh
+++ b/scripts/check-vocabulary-item-schema.sh
@@ -7,7 +7,7 @@ readme="$script_dir/../README.md"
 
 check_doc() {
   pattern="$1"
-  if ! grep -Fq "$pattern" "$doc"; then
+  if ! grep -Fq -- "$pattern" "$doc"; then
     printf 'missing required vocabulary schema content: %s\n' "$pattern" >&2
     exit 1
   fi
@@ -15,7 +15,7 @@ check_doc() {
 
 check_readme() {
   pattern="$1"
-  if ! grep -Fq "$pattern" "$readme"; then
+  if ! grep -Fq -- "$pattern" "$readme"; then
     printf 'missing README vocabulary-schema pointer: %s\n' "$pattern" >&2
     exit 1
   fi
@@ -27,11 +27,12 @@ check_doc "Required Fields"
 check_doc "Optional Fields"
 check_doc "Validation Behavior"
 check_doc "Reusability"
-check_doc "id"
-check_doc "term"
-check_doc "meaning"
-check_doc "imageAssetId"
-check_doc "audioAssetId"
+check_doc '- `id`:'
+check_doc '- `term`:'
+check_doc '- `meaning`:'
+check_doc '- `pronunciation`:'
+check_doc '- `imageAssetId`:'
+check_doc '- `audioAssetId`:'
 check_doc "Unknown fields are rejected"
 check_doc "Reject the item if any required field is missing."
 check_readme "docs/vocabulary-item-schema.md"


### PR DESCRIPTION
## What changed
- Added `docs/vocabulary-item-schema.md` as the canonical JSON schema for one vocabulary item.
- Documented required versus optional fields and validation behavior.
- Added a focused check script to keep the schema doc stable.
- Linked the schema doc from `README.md` for discoverability.

## Why
This issue needed a reusable vocabulary-item schema that pack and asset docs can reference without depending on pack-level concepts.

## Validation
- `./scripts/check-vocabulary-item-schema.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a canonical vocabulary item JSON schema document describing field shapes, required vs optional fields, validation rules (types, whitespace handling, tag rules), rejection of unknown fields, and treatment of asset IDs; intended for reuse across related docs.

* **Chores**
  * Added an automated check that verifies the new schema doc and README reference are present and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->