### PR TITLE
Epic 3.2 - Define schema for packs and stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ FNE stands for Friday Night English.
 The initial monorepo shape is documented in [docs/repo-boundaries.md](docs/repo-boundaries.md).
 The planning glossary for shared issue vocabulary lives in [docs/planning-glossary.md](docs/planning-glossary.md).
 The canonical vocabulary item schema lives in [docs/vocabulary-item-schema.md](docs/vocabulary-item-schema.md).
+The pack schema lives in [docs/pack-schema.md](docs/pack-schema.md).
+The stage schema lives in [docs/stage-schema.md](docs/stage-schema.md).
 The TypeScript usage policy lives in [docs/typescript-policy.md](docs/typescript-policy.md).
 The draft TypeScript compiler baseline lives in [docs/typescript-baseline.md](docs/typescript-baseline.md).
 The TypeScript compatibility review checklist lives in [docs/typescript-review-checklist.md](docs/typescript-review-checklist.md).

--- a/docs/pack-schema.md
+++ b/docs/pack-schema.md
@@ -1,0 +1,89 @@
+# Pack Schema
+
+## Status
+Proposed
+
+## Purpose
+Define the pack manifest shape so a pack can group vocabulary items into multiple stages and modes without changing the canonical item contract.
+
+## Pack Manifest Shape
+
+```json
+{
+  "schemaVersion": 1,
+  "id": "starter-pack",
+  "title": "Starter Pack",
+  "description": "Beginner vocabulary lessons for the first playtests.",
+  "vocabularyItems": [
+    {
+      "id": "apple",
+      "term": "apple",
+      "meaning": "りんご",
+      "pronunciation": "AP-uhl",
+      "imageAssetId": "img-apple",
+      "audioAssetId": "aud-apple"
+    }
+  ],
+  "stages": [
+    {
+      "id": "stage-fruit-1",
+      "title": "Fruit Basics",
+      "vocabularyItemIds": ["apple"],
+      "modeIds": ["practice"]
+    }
+  ],
+  "modes": [
+    {
+      "id": "practice",
+      "label": "Practice",
+      "description": "Low-pressure learning mode for first exposure."
+    }
+  ]
+}
+```
+
+## Pack Manifest Fields
+
+- `schemaVersion`: Manifest version number for future evolution.
+- `id`: Stable pack identifier string.
+- `title`: Pack display name.
+- `description`: Short pack summary for selection screens or documentation.
+- `vocabularyItems`: Array of vocabulary item objects that must satisfy the canonical vocabulary item schema.
+- `stages`: Ordered array of stage definitions that make up the pack.
+- `modes`: Array of pack-local mode definitions that describe how stages can run.
+- `notes`: Optional editorial metadata for internal use.
+
+## Stage Collection
+
+- A pack should support multiple stages, and the `stages` array is the progression order for the pack.
+- Stages may reuse the same vocabulary items when a later lesson needs review or mixed practice.
+- The pack manifest should not copy item fields into stage definitions.
+- The stage list should stay readable as a lesson sequence, not as a flattened engine table.
+
+## Mode Collection
+
+- Modes describe rule sets or presentation profiles that can be applied to one or more stages.
+- A mode should be defined once at the pack level when multiple stages share the same behavior.
+- Modes must remain separate from vocabulary content so changing a lesson mode does not mutate the item catalog.
+
+## Compatible with the canonical vocabulary item schema
+
+- Each entry in `vocabularyItems` must satisfy [docs/vocabulary-item-schema.md](vocabulary-item-schema.md) without pack-specific changes.
+- Pack validation should treat the item schema as authoritative for item shape and required fields.
+- Stage references should point to item `id` values from the pack item catalog, not to a second item shape.
+- If the vocabulary item schema expands later, the pack schema should continue to reuse it rather than redefining the item contract.
+
+## Validation Behavior
+
+- Reject the pack if `vocabularyItems` is missing or is not an array.
+- Reject the pack if `stages` is missing or is not an array.
+- Reject the pack if `modes` is present but is not an array.
+- Reject the pack if any stage references a vocabulary item id that is not present in `vocabularyItems`.
+- Reject the pack if any vocabulary item fails the canonical vocabulary item schema.
+- Reject unknown fields so the manifest stays predictable and easy to validate.
+
+## Reusability
+
+- This schema is intentionally pack-local and can be copied for a new lesson bundle without changing the runtime contract.
+- It can support multiple lessons per pack by adding more stage entries to the ordered `stages` array.
+- It stays compatible with item-level validation because the pack manifest reuses the canonical item schema instead of inventing a new item shape.

--- a/docs/stage-schema.md
+++ b/docs/stage-schema.md
@@ -1,0 +1,75 @@
+# Stage Schema
+
+## Status
+Proposed
+
+## Purpose
+Define the stage shape so a pack can reference vocabulary items by id and attach unlock and pass metadata without duplicating the item contract.
+
+## Stage Schema
+
+```json
+{
+  "id": "stage-fruit-1",
+  "title": "Fruit Basics",
+  "summary": "Learn the first fruit words in a short practice run.",
+  "vocabularyItemIds": ["apple", "banana"],
+  "modeIds": ["practice", "review"],
+  "unlock": {
+    "kind": "after-stage",
+    "stageIds": ["stage-intro"]
+  },
+  "pass": {
+    "kind": "score-threshold",
+    "minimumScore": 80,
+    "minimumAccuracy": 0.75
+  }
+}
+```
+
+## Stage Fields
+
+- `id`: Stable stage identifier string.
+- `title`: Stage display name.
+- `summary`: Short learner-facing description of the stage.
+- `vocabularyItemIds`: Ordered list of vocabulary item ids used in the stage.
+- `modeIds`: Ordered list of mode ids allowed for the stage.
+- `unlock`: Optional unlock metadata block.
+- `pass`: Optional pass metadata block.
+- `notes`: Optional editorial metadata for internal use.
+
+## Vocabulary Item References
+
+- A stage should point to vocabulary item ids from the owning pack.
+- The stage should never embed a second copy of the full vocabulary item shape.
+- The order of `vocabularyItemIds` should define the lesson flow for that stage.
+- If the same item appears in more than one stage, the pack manifest still relies on the same canonical item schema for the item itself.
+
+## Unlock Metadata
+
+- `unlock` describes when the stage becomes available to the learner.
+- Suggested `unlock.kind` values include `after-stage`, `immediate`, and `manual`.
+- When `unlock.kind` is `after-stage`, `stageIds` should identify the prerequisite stage or stages.
+- Unlock metadata should stay descriptive enough for content planning while remaining separate from runtime engine state.
+
+## Pass Metadata
+
+- `pass` describes what counts as completing the stage.
+- Suggested `pass.kind` values include `score-threshold`, `accuracy-threshold`, and `clear-all-items`.
+- `minimumScore` and `minimumAccuracy` can express simple thresholds for early content planning.
+- Pass metadata should define the completion bar without embedding engine-specific scoring code in the content schema.
+
+## Validation Behavior
+
+- Reject the stage if `id`, `title`, or `vocabularyItemIds` is missing.
+- Reject the stage if `vocabularyItemIds` is not an array of non-empty strings.
+- Reject the stage if `modeIds` is present but is not an array of non-empty strings.
+- Reject the stage if `unlock` or `pass` is present but is not an object.
+- Reject the stage if `unlock` or `pass` contains fields that are not described by the schema.
+- The stage should reject unknown fields so the schema stays stable and predictable.
+
+## Reusability
+
+- A stage should stay small enough to represent one lesson-sized progression step.
+- A pack can define multiple stages and reuse the same stage shape for each one.
+- The stage schema remains compatible with item-level validation because it only references vocabulary item ids rather than redefining item fields.

--- a/scripts/check-pack-stage-schema.sh
+++ b/scripts/check-pack-stage-schema.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+pack_doc="$script_dir/../docs/pack-schema.md"
+stage_doc="$script_dir/../docs/stage-schema.md"
+readme="$script_dir/../README.md"
+
+check_doc() {
+  file="$1"
+  pattern="$2"
+  if ! grep -Fq -- "$pattern" "$file"; then
+    printf 'missing required schema content in %s: %s\n' "$file" "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_readme() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$readme"; then
+    printf 'missing README pack/stage-schema pointer: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_doc "$pack_doc" "Pack Schema"
+check_doc "$pack_doc" "Pack Manifest Shape"
+check_doc "$pack_doc" "Pack Manifest Fields"
+check_doc "$pack_doc" "Stage Collection"
+check_doc "$pack_doc" "Mode Collection"
+check_doc "$pack_doc" "Compatible with the canonical vocabulary item schema"
+check_doc "$pack_doc" "multiple stages"
+check_doc "$stage_doc" "Stage Schema"
+check_doc "$stage_doc" "Stage Fields"
+check_doc "$stage_doc" "Vocabulary Item References"
+check_doc "$stage_doc" "Unlock Metadata"
+check_doc "$stage_doc" "Pass Metadata"
+check_doc "$stage_doc" "stage should reject unknown fields"
+check_readme "docs/pack-schema.md"
+check_readme "docs/stage-schema.md"
+
+printf 'pack and stage schema check passed\n'


### PR DESCRIPTION
Adds the pack and stage schema docs, plus a focused guard script that checks the docs and README links. The pack schema now defines an ordered stage collection, pack-local modes, and reuse of the canonical vocabulary item schema. The stage schema defines vocabulary item references, unlock metadata, and pass metadata.