### PR TITLE
Define safe mod contract v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The planning glossary for shared issue vocabulary lives in [docs/planning-glossa
 The canonical vocabulary item schema lives in [docs/vocabulary-item-schema.md](docs/vocabulary-item-schema.md).
 The pack schema lives in [docs/pack-schema.md](docs/pack-schema.md).
 The stage schema lives in [docs/stage-schema.md](docs/stage-schema.md).
+The mod contract lives in [docs/mod-contract.md](docs/mod-contract.md).
 The asset conventions live in [docs/asset-conventions.md](docs/asset-conventions.md).
 The TypeScript usage policy lives in [docs/typescript-policy.md](docs/typescript-policy.md).
 The draft TypeScript compiler baseline lives in [docs/typescript-baseline.md](docs/typescript-baseline.md).

--- a/docs/mod-contract.md
+++ b/docs/mod-contract.md
@@ -1,0 +1,45 @@
+# Mod Contract v1
+
+## Status
+Proposed
+
+## Purpose
+Define the narrow, data-only surface a first-wave mod may use so content expansion stays safe and the engine can validate mods without executing plugin code.
+
+## What A Mod Can Do
+
+- Provide pack-local content files for vocabulary, stages, and modes.
+- Reference existing item ids, asset ids, and stage ids through the published manifest shapes.
+- Add or update text, images, audio references, and other declared data-only metadata within the allowed schemas.
+- Define compatibility metadata through the manifest `schemaVersion` field so loaders can reject unsupported content cleanly.
+
+## What A Mod Cannot Do
+
+- A mod cannot include arbitrary code execution.
+- A mod cannot ship runtime hooks, scripts, eval-like payloads, or other executable behavior.
+- A mod cannot reach into engine internals or replace runtime systems from content files.
+- A mod cannot introduce new schema shapes that bypass the published pack, stage, mode, or item contracts.
+
+## Compatibility And Versioning
+
+- Version `1` is intentionally narrow and data-only.
+- Loaders should accept only mods that declare a supported `schemaVersion`.
+- A mod should be rejected if its version is unknown, missing, or incompatible with the current loader.
+- Backward compatibility should be maintained by adding new optional data fields only when they are documented in the contract first.
+- Breaking changes require a new major contract version rather than silently expanding v1.
+
+## Enforcement Rules
+
+- Validate mod content by schema and file layout only.
+- Reject any mod that requires code execution to interpret, load, or transform.
+- Reject unknown fields unless the contract explicitly allows them.
+- Keep the contract narrow enough that the engine can stay stable while the content surface expands.
+
+## Validation
+
+This contract is considered safe enough for first-wave content expansion when:
+
+- the mod surface remains data-only
+- arbitrary code execution is explicitly out of scope
+- version compatibility is checked before content is accepted
+- enforcement can be implemented without executing mod-provided code

--- a/scripts/check-mod-contract.sh
+++ b/scripts/check-mod-contract.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+doc="$script_dir/../docs/mod-contract.md"
+readme="$script_dir/../README.md"
+
+check_doc() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$doc"; then
+    printf 'missing required mod-contract content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_readme() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$readme"; then
+    printf 'missing README mod-contract pointer: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_doc "Mod Contract v1"
+check_doc "data-only surface"
+check_doc "arbitrary code execution"
+check_doc "schemaVersion"
+check_doc 'Version `1` is intentionally narrow and data-only.'
+check_doc "Reject any mod that requires code execution"
+check_doc "enforcement can be implemented without executing mod-provided code"
+check_readme "docs/mod-contract.md"
+
+printf 'mod contract check passed\n'


### PR DESCRIPTION
Adds a dedicated v1 mod contract doc, a narrow validation script that enforces the safety/versioning language, and a README pointer to the new contract.\n\nChecks:\n- sh scripts/check-mod-contract.sh\n- sh scripts/check-repo-boundaries.sh\n- sh scripts/check-pack-stage-schema.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Mod Contract v1 specification defining allowed mod capabilities, compatibility rules, and validation requirements for data-only content
  * Updated README with reference to new mod contract documentation

* **Chores**
  * Added validation script to ensure mod-contract compliance and documentation completeness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->