### PR TITLE
Specify Learn Mode

### DIFF
--- a/.codex-supervisor/issues/29/issue-journal.md
+++ b/.codex-supervisor/issues/29/issue-journal.md
@@ -1,0 +1,34 @@
+# Issue #29: Epic 4.1 - Specify Learn Mode
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/FNE/issues/29
+- Branch: codex/issue-29
+- Workspace: .
+- Journal: .codex-supervisor/issues/29/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 6c890e395c662f7cbcb8a95136b122c4ceab0544
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-10T08:14:14.398Z
+
+## Latest Codex Summary
+- Added a standalone Learn Mode behavior spec in `docs/learn-mode.md`, linked it from `README.md`, and introduced `scripts/check-learn-mode.sh` as the focused verification gate for flow, timing, difficulty assumptions, and pass conditions.
+
+## Active Failure Context
+- Initial reproducible gap: `./scripts/check-learn-mode.sh` failed with `no such file or directory`, which showed the repo had no focused Learn Mode spec or verification hook yet.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Issue #29 can be satisfied by adding a standalone Learn Mode spec plus a narrow shell check consistent with the repo's existing doc-validation pattern.
+- What changed: Created `docs/learn-mode.md`; added `scripts/check-learn-mode.sh`; added the README pointer to the new spec.
+- Current blocker: none
+- Next exact step: Commit the verified doc/check changes on `codex/issue-29`, then decide whether to open a draft PR for this checkpoint.
+- Verification gap: No broader doc aggregator exists in this repo yet, so verification is still by focused script execution.
+- Files touched: `README.md`, `docs/learn-mode.md`, `scripts/check-learn-mode.sh`, `.codex-supervisor/issues/29/issue-journal.md`
+- Rollback concern: low; changes are additive documentation and a focused check script.
+- Last focused command: `./scripts/check-learn-mode.sh`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- Verification run: `./scripts/check-learn-mode.sh`, `./scripts/check-planning-glossary.sh`, `./scripts/check-pack-stage-schema.sh`

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ FNE stands for Friday Night English.
 ## Repository Layout
 The initial monorepo shape is documented in [docs/repo-boundaries.md](docs/repo-boundaries.md).
 The planning glossary for shared issue vocabulary lives in [docs/planning-glossary.md](docs/planning-glossary.md).
+The Learn Mode behavior spec lives in [docs/learn-mode.md](docs/learn-mode.md).
 The canonical vocabulary item schema lives in [docs/vocabulary-item-schema.md](docs/vocabulary-item-schema.md).
 The pack schema lives in [docs/pack-schema.md](docs/pack-schema.md).
 The stage schema lives in [docs/stage-schema.md](docs/stage-schema.md).

--- a/docs/learn-mode.md
+++ b/docs/learn-mode.md
@@ -1,0 +1,70 @@
+# Learn Mode
+
+## Status
+Proposed
+
+## Purpose
+Define the first-exposure learner flow for Learn Mode so implementation can sequence prompts, cues, feedback, and completion rules without making pack-specific product decisions.
+
+## Mode Role
+
+- Learn Mode is the low-pressure mode used for first exposure to a vocabulary item.
+- It teaches one item at a time with a guided prompt, not a surprise recall test.
+- The mode stays independent from any specific content pack and only assumes each item can supply an image, pronunciation audio, and learner-facing text fields through the canonical content schemas.
+
+## Learner Flow
+
+1. The stage loads the next vocabulary item and resets any per-item streak or judgment state.
+2. Learn Mode starts with an attention cue so the learner knows a new item is about to begin.
+3. The image appears first as the primary meaning cue.
+4. The pronunciation audio plays immediately after the image is visible, or at the same moment if the implementation cannot separate them cleanly.
+5. The English term appears only after the learner has had a short first look at the image and heard the pronunciation once.
+6. The learner is prompted to respond on a simple confirmation beat or tap after the guided reveal.
+7. The mode judges the response with a forgiving timing rule and then gives immediate feedback.
+8. If the learner misses the response, the same item repeats with the same reveal order and an extra supportive cue before advancing.
+9. After the learner completes the required response for the item, the stage advances to the next item or to the end-of-stage summary.
+
+## Presentation Timeline
+
+- Image timing: show the image first and keep it visible for the rest of the item step.
+- Pronunciation timing: play pronunciation audio on first reveal before the text answer is shown.
+- Text timing: do not show the English term until after the first image-plus-audio exposure.
+- Optional meaning text, if shown at all, should appear only in feedback or recap moments and must not replace the image-first reveal.
+- The cue order is image, then pronunciation, then text, then response prompt.
+- Learn Mode should use short waits so the learner is never left guessing whether the game is waiting for input or still teaching the item.
+
+## Timing Cues
+
+- The new-item attention cue should be brief and consistent.
+- The gap between image reveal and pronunciation should be short enough that both cues read as one teaching moment.
+- The gap before the response prompt should give the learner time to hear the word once and orient to the image before acting.
+- Feedback should arrive immediately after the learner response so the cause-and-effect stays obvious.
+- A repeated item should reuse the same cue order with slightly stronger support, such as replaying the pronunciation or visually emphasizing the image, instead of introducing a new rule.
+
+## Learner Feedback
+
+- A successful response should confirm that the learner matched the cue correctly, with positive audiovisual feedback and no extra explanation wall.
+- A missed or late response should signal that the learner can try again without framing the first exposure as failure.
+- Feedback should support first exposure by reinforcing the same item cues rather than hiding them.
+- Learn Mode should avoid harsh fail states, score penalties, or progress loss on the first miss for a new item.
+
+## Difficulty Assumptions
+
+- Learn Mode assumes the learner may not know the word yet.
+- The mode is intentionally easier than later review-focused modes.
+- The hit window should be forgiving enough for beginners because the primary goal is pairing meaning, sound, and term rather than testing strict rhythm accuracy.
+- The reveal sequence should minimize reading load by relying on image and pronunciation before text.
+
+## Pass Conditions
+
+- An item counts as passed when the learner completes the guided response after the reveal sequence.
+- A first-try success may advance immediately after feedback.
+- A miss does not fail the item permanently; it triggers at least one supported repeat of the same item.
+- A stage in Learn Mode counts as cleared when every scheduled item has been passed at least once through this guided flow.
+- Learn Mode completion should be clear enough for implementation even if the broader stage scoring model changes later.
+
+## Implementation Boundaries
+
+- Learn Mode defines reveal order, cue timing intent, feedback posture, and pass conditions.
+- Learn Mode does not define pack-specific word order, art style, scoring formulas, or unlock rules.
+- If a later issue needs stricter timing tiers or adaptive repetition counts, that work should extend this mode spec rather than replacing the image-first first-exposure flow.

--- a/scripts/check-learn-mode.sh
+++ b/scripts/check-learn-mode.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+doc="$script_dir/../docs/learn-mode.md"
+readme="$script_dir/../README.md"
+
+check_doc() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$doc"; then
+    printf 'missing required Learn Mode content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_readme() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$readme"; then
+    printf 'missing README Learn Mode pointer: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_doc "Learn Mode"
+check_doc "Learner Flow"
+check_doc "Presentation Timeline"
+check_doc "Timing Cues"
+check_doc "Learner Feedback"
+check_doc "Difficulty Assumptions"
+check_doc "Pass Conditions"
+check_doc "independent from any specific content pack"
+check_doc "image, then pronunciation, then text, then response prompt"
+check_doc "forgiving enough for beginners"
+check_doc "miss does not fail the item permanently"
+check_doc "every scheduled item has been passed at least once"
+check_readme "docs/learn-mode.md"
+
+printf 'Learn Mode check passed\n'


### PR DESCRIPTION
## Summary
- add a standalone Learn Mode behavior spec in `docs/learn-mode.md`
- document learner flow, cue timing, feedback posture, difficulty assumptions, and pass conditions
- add a focused `scripts/check-learn-mode.sh` verifier and link the spec from `README.md`

## Reproduction
- `./scripts/check-learn-mode.sh` initially failed because the script and Learn Mode spec did not exist

## Verification
- `./scripts/check-learn-mode.sh`
- `./scripts/check-planning-glossary.sh`
- `./scripts/check-pack-stage-schema.sh`

Closes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Learn Mode specification detailing the learner flow for vocabulary items, including presentation sequence, feedback behavior, pass/clear conditions, and scope boundaries.
  * Updated documentation references to include the new Learn Mode specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->