### PR TITLE
Add Battle Mode specification

### DIFF
--- a/.codex-supervisor/issues/30/issue-journal.md
+++ b/.codex-supervisor/issues/30/issue-journal.md
@@ -1,0 +1,34 @@
+# Issue #30: Epic 4.2 - Specify Battle Mode
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/FNE/issues/30
+- Branch: codex/issue-30
+- Workspace: .
+- Journal: .codex-supervisor/issues/30/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 86d6e1a6ec7da92e94e27f63539b552190adcb9a
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-10T08:32:23.806Z
+
+## Latest Codex Summary
+- Added a focused Battle Mode documentation check, reproduced the issue as a missing `docs/battle-mode.md` spec, then added the spec and README pointer so the new check passes.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The narrowest reproducible failure is the absence of a Battle Mode spec and README pointer following the same pattern used by `docs/learn-mode.md` and `scripts/check-learn-mode.sh`.
+- What changed: Added `scripts/check-battle-mode.sh`; reproduced failure on missing `docs/battle-mode.md`; added `docs/battle-mode.md` covering lane layout, count structure, timing concept, vocabulary cadence, feedback/combo, fail state, and browser-first boundaries; added README link.
+- Current blocker: none
+- Next exact step: Commit the Battle Mode spec checkpoint, then open a draft PR if branch state remains coherent and no existing PR exists.
+- Verification gap: No broader docs aggregation script exists in this repo; focused shell checks passed for Battle Mode, Learn Mode, and product brief.
+- Files touched: README.md; docs/battle-mode.md; scripts/check-battle-mode.sh
+- Rollback concern: Low; changes are additive docs plus a focused validation script.
+- Last focused command: ./scripts/check-battle-mode.sh
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- Reproducer failure: `grep: .../docs/battle-mode.md: No such file or directory` followed by `missing required Battle Mode content: Battle Mode`.

--- a/.codex-supervisor/issues/30/issue-journal.md
+++ b/.codex-supervisor/issues/30/issue-journal.md
@@ -14,7 +14,7 @@
 - Updated at: 2026-04-10T08:32:23.806Z
 
 ## Latest Codex Summary
-- Added a focused Battle Mode documentation check, reproduced the issue as a missing `docs/battle-mode.md` spec, then added the spec and README pointer so the new check passes.
+- Added a focused Battle Mode documentation check, reproduced the issue as a missing `docs/battle-mode.md` spec, then added the spec and README pointer so the new check passes. Committed as `adfa6a0` and opened draft PR #34.
 
 ## Active Failure Context
 - None recorded.
@@ -24,7 +24,7 @@
 - Hypothesis: The narrowest reproducible failure is the absence of a Battle Mode spec and README pointer following the same pattern used by `docs/learn-mode.md` and `scripts/check-learn-mode.sh`.
 - What changed: Added `scripts/check-battle-mode.sh`; reproduced failure on missing `docs/battle-mode.md`; added `docs/battle-mode.md` covering lane layout, count structure, timing concept, vocabulary cadence, feedback/combo, fail state, and browser-first boundaries; added README link.
 - Current blocker: none
-- Next exact step: Commit the Battle Mode spec checkpoint, then open a draft PR if branch state remains coherent and no existing PR exists.
+- Next exact step: Monitor draft PR #34 for review feedback or supervisor follow-up; if requested, tighten wording or extend adjacent docs from this baseline.
 - Verification gap: No broader docs aggregation script exists in this repo; focused shell checks passed for Battle Mode, Learn Mode, and product brief.
 - Files touched: README.md; docs/battle-mode.md; scripts/check-battle-mode.sh
 - Rollback concern: Low; changes are additive docs plus a focused validation script.
@@ -32,3 +32,5 @@
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
 - Reproducer failure: `grep: .../docs/battle-mode.md: No such file or directory` followed by `missing required Battle Mode content: Battle Mode`.
+- Published branch: `origin/codex/issue-30`
+- Draft PR: https://github.com/TommyKammy/FNE/pull/34

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ FNE stands for Friday Night English.
 The initial monorepo shape is documented in [docs/repo-boundaries.md](docs/repo-boundaries.md).
 The planning glossary for shared issue vocabulary lives in [docs/planning-glossary.md](docs/planning-glossary.md).
 The Learn Mode behavior spec lives in [docs/learn-mode.md](docs/learn-mode.md).
+The Battle Mode behavior spec lives in [docs/battle-mode.md](docs/battle-mode.md).
 The canonical vocabulary item schema lives in [docs/vocabulary-item-schema.md](docs/vocabulary-item-schema.md).
 The pack schema lives in [docs/pack-schema.md](docs/pack-schema.md).
 The stage schema lives in [docs/stage-schema.md](docs/stage-schema.md).

--- a/docs/battle-mode.md
+++ b/docs/battle-mode.md
@@ -1,0 +1,65 @@
+# Battle Mode
+
+## Status
+Proposed
+
+## Purpose
+Define the FNF-style competitive rhythm mode so implementation can build lane flow, vocabulary cue timing, and failure handling without reopening the product thesis.
+
+## Mode Role
+
+- Battle Mode is the higher-pressure rhythm mode used after a learner has already seen the vocabulary in a more guided context.
+- The mode borrows the presentation energy of a music battle while keeping vocabulary recognition as the point of play rather than pure score chasing.
+- The mode stays independent from any specific content pack and only assumes each scheduled item can provide an image, pronunciation audio, and learner-facing text fields through the canonical content schemas.
+
+## Lane Layout
+
+- Battle Mode uses a four-lane layout that stays fixed for the full stage so the learner can build muscle memory.
+- Each lane maps to one directional input and one note column; implementation should not reassign lanes mid-song.
+- The learner playfield and the opponent presentation may be visually separated, but only the learner lanes need judged input in the first browser-first implementation.
+- Lane travel, receptors, and hit feedback should remain readable on laptop-class screens without requiring engine-specific HUD assumptions.
+
+## Count Structure
+
+- Battle Mode runs on a repeating four-count loop that groups note patterns into predictable measures.
+- Notes should snap to counts or subdivisions of those counts so the player can feel a stable beat even when vocabulary cues change.
+- A stage chart may vary density across measures, but the core teaching rhythm should avoid unreadable burst patterns in the first implementation pass.
+- Count readability matters more than advanced syncopation because the mode still supports vocabulary reinforcement, not expert-level rhythm mastery.
+
+## Timing Concept
+
+- Each note has a scheduled hit moment plus a defined hit window around that moment.
+- Timing judgment should stay strict enough to reward focus but forgiving enough that the learner can still process the vocabulary cue stream.
+- Empty lead-in and cooldown space should be intentional so the learner can recognize when a phrase starts, resolves, or transitions to a new word.
+- The first implementation may use a single success window for scoring as long as the surrounding feedback still distinguishes clean streaks from repeated misses.
+
+## Vocabulary Presentation Cadence
+
+- Each new target word starts with an image and pronunciation preview before its heaviest note phrase begins.
+- The image and pronunciation preview should land early enough that the learner knows what word is active before they must survive the densest input sequence tied to it.
+- The English term may appear as a compact label during or immediately after the preview, but it must not replace the image-first cue.
+- A target word should own a short phrase or measure group, then yield cleanly to the next word instead of switching vocabulary every beat.
+- If a word repeats in the same stage, reuse the same image and audio identity so the learner recognizes it as reinforcement rather than a new prompt.
+
+## Feedback and Combo
+
+- Judged hits should trigger immediate audiovisual confirmation at the lane receptor and preserve forward momentum.
+- Misses or late inputs should produce clear negative feedback without hiding the active vocabulary cue.
+- The combo rises only on judged hits and should break on a miss, late input, or other failed judgment.
+- Combo feedback should celebrate consistency, but it must not overwhelm the vocabulary image, pronunciation cue, or lane readability.
+- End-of-phrase feedback may summarize streak quality or survival state, but the player should still understand the result beat by beat during play.
+
+## Fail State
+
+- Battle Mode uses a visible performance meter that represents whether the learner is holding the round together.
+- The meter drains only on misses, late inputs, or empty measures where required notes were not hit.
+- Strong play can stabilize or recover the meter, but recovery should be slower than combo gain so failure pressure still feels real.
+- A stage fails when the meter fully empties before the chart ends.
+- On failure, the mode should offer a fast restart or return path without losing browser-session progress outside the current run.
+
+## Implementation Boundaries
+
+- Battle Mode defines lane count, count structure, vocabulary cue cadence, combo behavior, and fail-state intent.
+- Battle Mode does not define pack-specific chart authoring tools, narrative staging, asset style, or final scoring formulas beyond combo and survival expectations.
+- The first implementation should remain compatible with the browser-first runtime split in [docs/architecture.md](architecture.md): Phaser owns chart timing and hit detection, while React may own surrounding HUD, prompts, and retry flow.
+- If a later issue needs opponent AI, multiple judgment tiers, or difficulty variants, that work should extend this spec rather than replace the four-lane, four-count vocabulary battle baseline.

--- a/scripts/check-battle-mode.sh
+++ b/scripts/check-battle-mode.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+doc="$script_dir/../docs/battle-mode.md"
+readme="$script_dir/../README.md"
+
+check_doc() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$doc"; then
+    printf 'missing required Battle Mode content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_readme() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$readme"; then
+    printf 'missing README Battle Mode pointer: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_doc "Battle Mode"
+check_doc "Lane Layout"
+check_doc "Count Structure"
+check_doc "Vocabulary Presentation Cadence"
+check_doc "Feedback and Combo"
+check_doc "Fail State"
+check_doc "Implementation Boundaries"
+check_doc "four-lane"
+check_doc "four-count loop"
+check_doc "image and pronunciation preview"
+check_doc "combo rises only on judged hits"
+check_doc "drains only on misses, late inputs, or empty measures"
+check_readme "docs/battle-mode.md"
+
+printf 'Battle Mode check passed\n'


### PR DESCRIPTION
## Summary
- add a focused Battle Mode documentation check
- document Battle Mode lane layout, timing, vocabulary cadence, combo, and fail-state rules
- link the new Battle Mode spec from the README

## Testing
- ./scripts/check-battle-mode.sh
- ./scripts/check-learn-mode.sh
- ./scripts/check-product-brief.sh

Refs #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive Battle Mode specification detailing gameplay mechanics, four-lane layout, note timing, vocabulary presentation, feedback behavior, combo rules, and performance meter fail-state.
  * Updated README to reference the new Battle Mode documentation.

* **Chores**
  * Added automated validation for Battle Mode documentation completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->