### PR TITLE
Specify review and weak-word loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ FNE stands for Friday Night English.
 The initial monorepo shape is documented in [docs/repo-boundaries.md](docs/repo-boundaries.md).
 The planning glossary for shared issue vocabulary lives in [docs/planning-glossary.md](docs/planning-glossary.md).
 The Learn Mode behavior spec lives in [docs/learn-mode.md](docs/learn-mode.md).
+The review and weak-word loop spec lives in [docs/review-loop.md](docs/review-loop.md).
 The Battle Mode behavior spec lives in [docs/battle-mode.md](docs/battle-mode.md).
 The Listen & Match Mode behavior spec lives in [docs/listen-and-match-mode.md](docs/listen-and-match-mode.md).
 The canonical vocabulary item schema lives in [docs/vocabulary-item-schema.md](docs/vocabulary-item-schema.md).

--- a/docs/review-loop.md
+++ b/docs/review-loop.md
@@ -1,0 +1,47 @@
+# Review and Weak-Word Loop
+
+## Status
+Proposed
+
+## Purpose
+Define how incorrect, unresolved, or weak items come back for practice so implementation can resurface them without reopening the Learn Mode, Listen & Match Mode, or Battle Mode contracts.
+
+## Weak Word Entry Criteria
+
+- A weak word is a scheduled vocabulary item that still needs end-of-cycle review because the learner did not show a clean first-pass result.
+- A supported repeat in Learn Mode marks the item as weak for the current stage, even if the learner eventually clears the item on that repeat, because the first guided pass was not enough.
+- An unresolved target in Listen & Match marks the item as weak for the current stage because the learner could not complete the recognition prompt within the mode's allowed retry structure.
+- A failed Battle Mode phrase or stage-ending failure on an active vocabulary item marks that item as weak for the current stage because the learner did not hold the cue successfully in the higher-pressure context.
+- A clean first-pass clear in the active mode does not mark the item as weak.
+- Weak-word status belongs to the learner's current run outcome, not to permanent pack authoring metadata or a new vocabulary-item schema field.
+
+## Re-entry Rules
+
+- The review loop should queue weak words only after the stage has offered each scheduled item one first-pass exposure in its planned order.
+- The first review pass should requeue each weak word once in the order the learner originally weakened it, so the learner sees a short and understandable recovery sequence instead of a reshuffled backlog.
+- If a resurfaced weak word is cleared cleanly on its review pass, it leaves the current-stage review queue.
+- If a resurfaced weak word still resolves with support, retry reduction, or unresolved status, it may remain in the queue for one more short recovery pass, but the loop should stay finite and should not trap the learner in endless retries.
+- When the stage reaches its defined short review limit and some weak words are still unresolved, the stage should mark them for summary or future follow-up rather than silently dropping them.
+
+## Review Session Behavior
+
+- A review session should feel like a continuation of the same stage, not like a separate study screen or menu jump.
+- Each resurfaced item should return as a fresh prompt under that mode's normal rules, not as a frozen retry state from the earlier miss.
+- Learn Mode resurfacing should reuse the image-first guided flow, but it may shorten nonessential waits because the learner has already seen the item once in the same stage.
+- Listen & Match resurfacing should present a normal recognition prompt with a valid distractor set instead of replaying the exact failed tap state.
+- Battle Mode resurfacing should return the vocabulary cue through a normal phrase-sized challenge rather than rewinding the entire song or demanding a full-stage restart for one weak word.
+- Review results should remain visible in the stage summary so implementation can distinguish clean clears, supported clears, and still-unresolved weak words.
+
+## Mode Compatibility
+
+- This loop should work with existing mode boundaries by consuming outcome signals that the mode specs already imply, not by rewriting those mode rules.
+- Learn Mode remains the first-exposure mode, while the review loop decides whether an item returns later in the same stage after that first exposure cycle.
+- Listen & Match and Battle Mode keep their own retry and failure behavior; the review loop only decides whether unresolved items re-enter practice after the first pass is over.
+- Stage and pack schemas do not need new required fields for the baseline loop, because the queue can be built from existing stage item order, mode order, and runtime outcomes.
+- The baseline loop closes the first learning cycle cleanly: first exposure happens, weak items are identified, weak items resurface for short recovery, and any leftovers are visible for later systems.
+
+## Future Extension Boundary
+
+- This spec defines the short in-stage review loop only.
+- future spaced repetition layers should extend this same weak-word state instead of replacing the current-stage recovery rules with a second incompatible concept.
+- Later issues may add durability scoring, cross-session scheduling, or mastery decay, but those systems should treat this loop as the first recovery layer rather than reworking earlier mode specs.

--- a/scripts/check-review-loop.sh
+++ b/scripts/check-review-loop.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+doc="$script_dir/../docs/review-loop.md"
+readme="$script_dir/../README.md"
+
+check_doc() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$doc"; then
+    printf 'missing required review loop content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_readme() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$readme"; then
+    printf 'missing README review loop pointer: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_doc "Review and Weak-Word Loop"
+check_doc "Weak Word Entry Criteria"
+check_doc "Re-entry Rules"
+check_doc "Review Session Behavior"
+check_doc "Mode Compatibility"
+check_doc "Future Extension Boundary"
+check_doc "needs end-of-cycle review"
+check_doc "supported repeat in Learn Mode"
+check_doc "unresolved target in Listen & Match"
+check_doc "failed Battle Mode phrase"
+check_doc "queue weak words only after the stage has offered each scheduled item one first-pass exposure"
+check_doc "fresh prompt under that mode's normal rules"
+check_doc "closes the first learning cycle cleanly"
+check_doc "future spaced repetition layers should extend this same weak-word state"
+check_readme "docs/review-loop.md"
+
+printf 'Review loop check passed\n'

--- a/scripts/check-review-loop.sh
+++ b/scripts/check-review-loop.sh
@@ -5,6 +5,16 @@ script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 doc="$script_dir/../docs/review-loop.md"
 readme="$script_dir/../README.md"
 
+[ -f "$doc" ] || {
+  printf 'missing required file: %s\n' "$doc" >&2
+  exit 1
+}
+
+[ -f "$readme" ] || {
+  printf 'missing required file: %s\n' "$readme" >&2
+  exit 1
+}
+
 check_doc() {
   pattern="$1"
   if ! grep -Fq -- "$pattern" "$doc"; then


### PR DESCRIPTION
## Summary
- add a dedicated review and weak-word loop spec
- define weak-word entry criteria, re-entry rules, and review-session behavior
- add a focused shell check and README pointer for the new doc

Closes #32

## Verification
- ./scripts/check-review-loop.sh
- ./scripts/check-learn-mode.sh
- ./scripts/check-planning-glossary.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * New documentation describing the review and weak-word loop lifecycle—how vocabulary items become weak based on learning outcomes across different modes and how they're strategically resurfaced during review sessions while maintaining progress visibility in stage summaries.

* **Chores**
  * Added validation tooling to ensure documentation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->