### PR TITLE
Define shared UX readability and input simplicity rules

### DIFF
--- a/.codex-supervisor/issues/38/issue-journal.md
+++ b/.codex-supervisor/issues/38/issue-journal.md
@@ -1,0 +1,34 @@
+# Issue #38: Epic 5.1 - Define visual readability and input simplicity rules
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/FNE/issues/38
+- Branch: codex/issue-38
+- Workspace: .
+- Journal: .codex-supervisor/issues/38/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 241ff6fcb69d907319c1e2859f8ee8638551424c
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-10T09:24:38.287Z
+
+## Latest Codex Summary
+- Added a focused UX-rules documentation check, reproduced the gap as a missing `docs/ux-rules.md` file, then added the new shared UX rules spec and README pointer.
+
+## Active Failure Context
+- Reproduced initially with `sh scripts/check-ux-rules.sh`, which failed on missing `docs/ux-rules.md`.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Issue #38 needs a dedicated shared UX rules spec, and the narrowest proof is a new shell check that asserts required readability, simplicity, and recovery content.
+- What changed: Added `scripts/check-ux-rules.sh`; reproduced failure on missing `docs/ux-rules.md`; added `docs/ux-rules.md` and a README pointer; reran focused doc checks successfully.
+- Current blocker: none
+- Next exact step: Commit the UX rules checkpoint on `codex/issue-38`.
+- Verification gap: No broader aggregate check runner exists in this workspace; verification was done with focused shell checks only.
+- Files touched: README.md, docs/ux-rules.md, scripts/check-ux-rules.sh, .codex-supervisor/issues/38/issue-journal.md
+- Rollback concern: Low; this change adds a new doc contract and shared spec text without changing existing mode behavior docs.
+- Last focused command: sh scripts/check-ux-rules.sh
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- 2026-04-10T09:27:01Z: `sh scripts/check-ux-rules.sh` now passes. Adjacent checks also pass: learn-mode, listen-and-match-mode, battle-mode.

--- a/.codex-supervisor/issues/38/issue-journal.md
+++ b/.codex-supervisor/issues/38/issue-journal.md
@@ -5,30 +5,40 @@
 - Branch: codex/issue-38
 - Workspace: .
 - Journal: .codex-supervisor/issues/38/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 241ff6fcb69d907319c1e2859f8ee8638551424c
+- Current phase: stabilizing
+- Attempt count: 2 (implementation=2, repair=0)
+- Last head SHA: ba359e0a5c698f3814ac691f9301d26fcc67fbb0
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-10T09:24:38.287Z
+- Updated at: 2026-04-10T09:30:05.318Z
 
 ## Latest Codex Summary
-- Added a focused UX-rules documentation check, reproduced the gap as a missing `docs/ux-rules.md` file, then added the new shared UX rules spec and README pointer.
+Added a dedicated shared UX rules spec in [docs/ux-rules.md](docs/ux-rules.md), linked it from [README.md](README.md), and added a focused reproducing check in [scripts/check-ux-rules.sh](scripts/check-ux-rules.sh). The new spec covers visual readability, input simplicity, failure/retry feedback, and cross-mode application without binding later implementation details.
+
+I reproduced the gap first with `sh scripts/check-ux-rules.sh`, which failed on a missing `docs/ux-rules.md`, then fixed it and committed the checkpoint as `ba359e0` (`Add shared UX readability rules spec`). I pushed `codex/issue-38` and opened draft PR #41: https://github.com/TommyKammy/FNE/pull/41
+
+Summary: Added and verified the shared UX readability/input simplicity spec, pushed the branch, and opened draft PR #41.
+State hint: pr_open
+Blocked reason: none
+Tests: `sh scripts/check-ux-rules.sh`; `sh scripts/check-learn-mode.sh`; `sh scripts/check-listen-and-match-mode.sh`; `sh scripts/check-battle-mode.sh`
+Next action: Wait for PR review or follow-up feedback on PR #41.
+Failure signature: none
 
 ## Active Failure Context
-- Reproduced initially with `sh scripts/check-ux-rules.sh`, which failed on missing `docs/ux-rules.md`.
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: Issue #38 needs a dedicated shared UX rules spec, and the narrowest proof is a new shell check that asserts required readability, simplicity, and recovery content.
-- What changed: Added `scripts/check-ux-rules.sh`; reproduced failure on missing `docs/ux-rules.md`; added `docs/ux-rules.md` and a README pointer; reran focused doc checks successfully.
+- Hypothesis: The issue is satisfied by a shared UX rules spec plus a focused doc contract check; remaining work is review-oriented rather than implementation-oriented.
+- What changed: Added `scripts/check-ux-rules.sh`; reproduced failure on missing `docs/ux-rules.md`; added `docs/ux-rules.md` and a README pointer; reran focused doc checks successfully; pushed `codex/issue-38`; opened draft PR #41.
 - Current blocker: none
-- Next exact step: Commit the UX rules checkpoint on `codex/issue-38`.
+- Next exact step: Monitor PR #41 for review feedback or CI updates.
 - Verification gap: No broader aggregate check runner exists in this workspace; verification was done with focused shell checks only.
 - Files touched: README.md, docs/ux-rules.md, scripts/check-ux-rules.sh, .codex-supervisor/issues/38/issue-journal.md
 - Rollback concern: Low; this change adds a new doc contract and shared spec text without changing existing mode behavior docs.
-- Last focused command: sh scripts/check-ux-rules.sh
+- Last focused command: gh pr create --draft --base main --head codex/issue-38 --title "Define shared UX readability and input simplicity rules" --body ...
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
 - 2026-04-10T09:27:01Z: `sh scripts/check-ux-rules.sh` now passes. Adjacent checks also pass: learn-mode, listen-and-match-mode, battle-mode.
+- 2026-04-10T09:32Z: Pushed `codex/issue-38` and opened draft PR #41 after the GitHub app create-PR call returned 403.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The Learn Mode behavior spec lives in [docs/learn-mode.md](docs/learn-mode.md).
 The review and weak-word loop spec lives in [docs/review-loop.md](docs/review-loop.md).
 The Battle Mode behavior spec lives in [docs/battle-mode.md](docs/battle-mode.md).
 The Listen & Match Mode behavior spec lives in [docs/listen-and-match-mode.md](docs/listen-and-match-mode.md).
+The shared visual readability and input simplicity rules live in [docs/ux-rules.md](docs/ux-rules.md).
 The canonical vocabulary item schema lives in [docs/vocabulary-item-schema.md](docs/vocabulary-item-schema.md).
 The pack schema lives in [docs/pack-schema.md](docs/pack-schema.md).
 The stage schema lives in [docs/stage-schema.md](docs/stage-schema.md).

--- a/docs/ux-rules.md
+++ b/docs/ux-rules.md
@@ -1,0 +1,55 @@
+# Visual Readability and Input Simplicity Rules
+
+## Status
+Proposed
+
+## Purpose
+Define the shared readability, interaction, and recovery rules that keep every FNE mode understandable for a junior-high learner without locking the product to a later UI implementation.
+
+## Scope
+
+- These rules apply to learner-facing surfaces across Learn Mode, Listen & Match Mode, Battle Mode, summary screens, and retry flows.
+- The rules should reduce reading load, keep actions obvious, and preserve the browser-first learning loop.
+- The rules define product constraints, not final art direction, component libraries, or engine-specific HUD code.
+
+## Visual Readability Rules
+
+- The screen should present one dominant teaching focus at a time so the learner can tell whether the current priority is image recognition, pronunciation, lane timing, choice selection, or recovery.
+- Text should stay short, direct, and written for a junior-high learner who may already be splitting attention between reading, audio, and timing.
+- Core instructional text and interactive controls should remain high-contrast against their background so they are readable on laptop-class screens and small touch devices.
+- The product should prefer persistent layout zones over frequent UI reshuffles so learners are not forced to re-scan the whole screen between prompts.
+- Motion should reinforce timing, attention, or outcome state, not decorate the screen with extra movement that competes with the active learning cue.
+- Animated effects should pause or soften once the learner needs to read, choose, or recover from a miss.
+- When text, image, and audio appear together, the image and spoken cue should carry the first teaching moment and text should support rather than replace them.
+- Secondary metadata such as streaks, counts, or recap details should stay visually quieter than the current vocabulary cue or current action target.
+
+## Input Simplicity Rules
+
+- Each step should expose a single primary action so the learner does not have to infer which button, lane, or choice matters most.
+- If a surface needs secondary actions, there should be no more than two non-primary actions visible at once, and they should be clearly separated from the main task.
+- Input expectations should stay consistent inside a mode so the learner can build habit instead of relearning controls every round.
+- A prompt should not require simultaneous reading of long text and execution of precise timing on the same beat.
+- Choice sets, tap targets, and confirm actions should stay large enough to be selected confidently on common browser devices without precision-pointer assumptions.
+- If a mode uses timing input, the learner should still be able to identify the target action before the input window opens.
+- Extra configuration, branching menus, or advanced control options should stay outside the core learning loop unless a later issue proves they are necessary.
+
+## Failure and Retry Feedback
+
+- A miss, wrong answer, or interrupted run should explain what happened in plain language or equally clear audiovisual feedback.
+- The same recovery moment should also tell the learner what to do next, such as retry now, continue, or return to the previous safe point.
+- Failure feedback should avoid blame-heavy phrasing and should frame retry as part of learning rather than punishment.
+- Recovery screens should keep the next action obvious and should not hide it behind dense recap text or multiple competing buttons.
+- If the learner can retry immediately, the retry path should preserve enough context that the learner still remembers the active word or task.
+- If the flow moves on after an unresolved attempt, the product should clearly mark that the item will come back later or that the round is continuing without trapping the learner.
+
+## Cross-Mode Application
+
+- Learn Mode should use these rules to keep reveals readable, response prompts obvious, and supportive repeats calmer than punitive fail states.
+- Listen & Match Mode should use these rules to keep the spoken target, visible choice set, and retry state understandable without cluttering the response area.
+- Battle Mode should use these rules to protect lane readability, keep the active vocabulary cue visible, and make restart or exit decisions obvious after failure.
+- Summary and review surfaces should use the same plain-language and low-clutter approach so the learner does not leave the browser-first learning loop when a mode ends.
+
+## Implementation Boundary
+
+- These rules stay compatible with the browser-first learning loop by describing readability and interaction outcomes instead of prescribing framework, engine, animation library, or component structure.
+- Later UI issues may extend typography scales, color tokens, accessibility checks, or mode-specific layouts, but they should preserve these baseline readability and simplicity constraints.

--- a/scripts/check-ux-rules.sh
+++ b/scripts/check-ux-rules.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+doc="$script_dir/../docs/ux-rules.md"
+readme="$script_dir/../README.md"
+
+[ -f "$doc" ] || {
+  printf 'missing required file: %s\n' "$doc" >&2
+  exit 1
+}
+
+[ -f "$readme" ] || {
+  printf 'missing required file: %s\n' "$readme" >&2
+  exit 1
+}
+
+check_doc() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$doc"; then
+    printf 'missing required UX rules content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_readme() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$readme"; then
+    printf 'missing README UX rules pointer: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_doc "Visual Readability and Input Simplicity Rules"
+check_doc "Visual Readability Rules"
+check_doc "Input Simplicity Rules"
+check_doc "Failure and Retry Feedback"
+check_doc "Cross-Mode Application"
+check_doc "Implementation Boundary"
+check_doc "junior-high learner"
+check_doc "high-contrast"
+check_doc "single primary action"
+check_doc "no more than two"
+check_doc "what happened"
+check_doc "what to do next"
+check_doc "browser-first learning loop"
+check_readme "docs/ux-rules.md"
+
+printf 'UX rules check passed\n'


### PR DESCRIPTION
## Summary
- add a shared UX rules spec for visual readability, input simplicity, and failure/retry feedback
- link the new spec from the README alongside the other product/spec docs
- add a focused shell check that reproduces and verifies the documentation contract for issue #38

## Verification
- sh scripts/check-ux-rules.sh
- sh scripts/check-learn-mode.sh
- sh scripts/check-listen-and-match-mode.sh
- sh scripts/check-battle-mode.sh

Closes #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented visual readability standards for all learning modes: clear text, high contrast, consistent layouts, restrained animations, and single-focus design.
  * Specified input simplicity requirements: accessible tap targets, clear primary actions, and consistent controls.
  * Defined failure/retry feedback expectations: plain-language explanations with immediate next-step guidance and context preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->