### PR TITLE
Define accessibility baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The review and weak-word loop spec lives in [docs/review-loop.md](docs/review-lo
 The Battle Mode behavior spec lives in [docs/battle-mode.md](docs/battle-mode.md).
 The Listen & Match Mode behavior spec lives in [docs/listen-and-match-mode.md](docs/listen-and-match-mode.md).
 The shared visual readability and input simplicity rules live in [docs/ux-rules.md](docs/ux-rules.md).
+The practical accessibility baseline lives in [docs/accessibility-baseline.md](docs/accessibility-baseline.md).
 The canonical vocabulary item schema lives in [docs/vocabulary-item-schema.md](docs/vocabulary-item-schema.md).
 The pack schema lives in [docs/pack-schema.md](docs/pack-schema.md).
 The stage schema lives in [docs/stage-schema.md](docs/stage-schema.md).

--- a/docs/accessibility-baseline.md
+++ b/docs/accessibility-baseline.md
@@ -1,0 +1,46 @@
+# Accessibility Baseline
+
+## Status
+Proposed
+
+## Purpose
+Define the minimum accessibility expectations for the first implementation planning pass so text, audio-backed learning, and core interactions can be reviewed without guessing intent.
+
+## Scope
+
+- This baseline covers learner-facing text, visible state changes, audio-backed prompts, and core play interaction across Learn Mode, Listen & Match Mode, Battle Mode, and retry or summary surfaces.
+- The baseline is intentionally practical for first implementation planning and does not attempt to define a full compliance program, platform-wide assistive technology matrix, or final component library rules.
+- The baseline adds explicit accessibility expectations alongside [docs/ux-rules.md](ux-rules.md), which already defines the broader readability and simplicity direction.
+
+## Visual Clarity Baseline
+
+- Core instructional text, current vocabulary cues, and primary actions should remain readable on laptop-class screens and common tablet or phone widths without relying on tiny helper text.
+- Text and control states should stay high-contrast against their background so the active prompt, current selection, and recovery action remain obvious during play.
+- The active element, selected answer, current lane target, and disabled or unavailable controls should each have a visible state that does not depend on color alone.
+- Every keyboard-reachable control should show a persistent focus indicator that remains visible against the current screen treatment.
+- Layouts should preserve meaning and operability at 200% zoom on browser-sized play surfaces without hiding the current prompt, the next required action, or the exit or retry path behind overlapping UI.
+- Motion, flashes, and celebratory effects should not hide the current word, the focus indicator, or the next required action while the learner needs to read or respond.
+
+## Audio Dependence Fallback
+
+- Audio may stay a primary teaching cue, but core play should still remain understandable without requiring audio at every decision point.
+- If pronunciation audio introduces a word or target, the learner should also receive a synchronized visible cue that identifies the active item, response set, or timing context.
+- A learner who cannot hear clearly, must keep volume low, or chooses to mute should still be able to tell which word or prompt is active and what action the game expects next.
+- The product should provide a visible way to replay the current pronunciation or teaching cue when the mode depends on hearing it once.
+- The product should provide a visible mute or volume-lowering path that does not remove the learner's ability to continue the round.
+- Audio-only alerts for success, failure, countdowns, or state changes are not sufficient; the same state change should also appear through visible text, motion, iconography, or another clear on-screen signal.
+
+## Keyboard-First and Non-Pointer Play
+
+- Core play must be operable keyboard-only for the first implementation baseline.
+- A learner should be able to start, advance, confirm, retry, pause if available, and exit core play without a mouse.
+- If a mode uses directional lanes, menu choices, or answer cards, the keyboard mapping should stay consistent enough that the learner can build habit across repeated attempts.
+- Interactive elements should follow a predictable focus order so keyboard-only play does not jump unpredictably around the screen.
+- Pointer input may coexist with keyboard controls, but the baseline should not require hover-only discovery, drag-only actions, or precision clicking for core play.
+- Non-pointer expectations apply to the same core play loop as pointer expectations: the learner should be able to complete a guided reveal, make a choice, respond to timing prompts, and recover from failure without a mouse.
+
+## Review Boundary
+
+- This baseline is specific enough to review first implementation planning against text readability, visible states, audio fallback, and keyboard-first core play expectations.
+- This baseline does not yet define formal screen reader support, localization rules, remappable controls, caption authoring, or full audit procedures unless a later issue expands scope.
+- Review should confirm that mode specs and UI planning drafts do not introduce audio-only progression gates, pointer-only core actions, or unreadable state changes.

--- a/scripts/check-accessibility-baseline.sh
+++ b/scripts/check-accessibility-baseline.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+doc="$script_dir/../docs/accessibility-baseline.md"
+readme="$script_dir/../README.md"
+
+[ -f "$doc" ] || {
+  printf 'missing required file: %s\n' "$doc" >&2
+  exit 1
+}
+
+[ -f "$readme" ] || {
+  printf 'missing required file: %s\n' "$readme" >&2
+  exit 1
+}
+
+check_doc() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$doc"; then
+    printf 'missing required accessibility baseline content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_readme() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$readme"; then
+    printf 'missing README accessibility baseline pointer: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_doc "Accessibility Baseline"
+check_doc "Visual Clarity Baseline"
+check_doc "Audio Dependence Fallback"
+check_doc "Keyboard-First and Non-Pointer Play"
+check_doc "Review Boundary"
+check_doc "focus indicator"
+check_doc "200%"
+check_doc "mute"
+check_doc "replay"
+check_doc "without requiring audio"
+check_doc "keyboard-only"
+check_doc "without a mouse"
+check_doc "core play"
+check_doc "first implementation planning"
+check_readme "docs/accessibility-baseline.md"
+
+printf 'Accessibility baseline check passed\n'


### PR DESCRIPTION
## Summary
- add a practical accessibility baseline spec for first-pass planning
- cover visual clarity, audio fallback, and keyboard-first non-pointer expectations
- add a focused shell check and README pointer for the new doc

Closes #39

## Verification
- sh scripts/check-accessibility-baseline.sh
- sh scripts/check-ux-rules.sh