### PR TITLE
Define parent observation features for v1 planning

### DIFF
--- a/.codex-supervisor/issues/40/issue-journal.md
+++ b/.codex-supervisor/issues/40/issue-journal.md
@@ -14,7 +14,7 @@
 - Updated at: 2026-04-10T10:18:20.695Z
 
 ## Latest Codex Summary
-- Added a focused parent-observation planning check, reproduced the missing-spec failure, and added a minimal spec plus README pointer so the new check passes.
+- Added a focused parent-observation planning check, reproduced the missing-spec failure, added a minimal spec plus README pointer so the new check passes, then committed and opened draft PR #43.
 
 ## Active Failure Context
 - None recorded.
@@ -22,12 +22,12 @@
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: Issue #40 is a missing planning artifact rather than an implementation bug; the narrowest reproducible gap is the absence of a parent-observation spec and its validation check.
-- What changed: Added `scripts/check-parent-observation.sh`, reproduced failure on missing `docs/parent-observation.md`, then added `docs/parent-observation.md` and a README pointer with explicitly minimal v1 parent-progress metrics and later-scope separation.
+- What changed: Added `scripts/check-parent-observation.sh`, reproduced failure on missing `docs/parent-observation.md`, then added `docs/parent-observation.md` and a README pointer with explicitly minimal v1 parent-progress metrics and later-scope separation. Committed as `a00f8b6` and opened draft PR #43.
 - Current blocker: none
-- Next exact step: Commit the focused doc-and-check checkpoint on `codex/issue-40`.
+- Next exact step: Review draft PR #43 and continue only if follow-up planning feedback requires refinement.
 - Verification gap: Only the new focused shell check was run; no broader doc sweep was run because the issue scope is isolated to the new planning artifact.
 - Files touched: README.md; docs/parent-observation.md; scripts/check-parent-observation.sh; .codex-supervisor/issues/40/issue-journal.md
 - Rollback concern: Low; changes are additive documentation plus a focused validation script.
-- Last focused command: sh scripts/check-parent-observation.sh
+- Last focused command: gh pr create --draft --base main --head codex/issue-40 --title "Define parent observation features for v1 planning" --body ...
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/40/issue-journal.md
+++ b/.codex-supervisor/issues/40/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #40: Epic 5.3 - Define parent observation features for v1 planning
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/FNE/issues/40
+- Branch: codex/issue-40
+- Workspace: .
+- Journal: .codex-supervisor/issues/40/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: c6fd9b6e268d0df685d5342be26bd3823f1a5854
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-10T10:18:20.695Z
+
+## Latest Codex Summary
+- Added a focused parent-observation planning check, reproduced the missing-spec failure, and added a minimal spec plus README pointer so the new check passes.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Issue #40 is a missing planning artifact rather than an implementation bug; the narrowest reproducible gap is the absence of a parent-observation spec and its validation check.
+- What changed: Added `scripts/check-parent-observation.sh`, reproduced failure on missing `docs/parent-observation.md`, then added `docs/parent-observation.md` and a README pointer with explicitly minimal v1 parent-progress metrics and later-scope separation.
+- Current blocker: none
+- Next exact step: Commit the focused doc-and-check checkpoint on `codex/issue-40`.
+- Verification gap: Only the new focused shell check was run; no broader doc sweep was run because the issue scope is isolated to the new planning artifact.
+- Files touched: README.md; docs/parent-observation.md; scripts/check-parent-observation.sh; .codex-supervisor/issues/40/issue-journal.md
+- Rollback concern: Low; changes are additive documentation plus a focused validation script.
+- Last focused command: sh scripts/check-parent-observation.sh
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The Learn Mode behavior spec lives in [docs/learn-mode.md](docs/learn-mode.md).
 The review and weak-word loop spec lives in [docs/review-loop.md](docs/review-loop.md).
 The Battle Mode behavior spec lives in [docs/battle-mode.md](docs/battle-mode.md).
 The Listen & Match Mode behavior spec lives in [docs/listen-and-match-mode.md](docs/listen-and-match-mode.md).
+The parent observation planning spec lives in [docs/parent-observation.md](docs/parent-observation.md).
 The shared visual readability and input simplicity rules live in [docs/ux-rules.md](docs/ux-rules.md).
 The practical accessibility baseline lives in [docs/accessibility-baseline.md](docs/accessibility-baseline.md).
 The canonical vocabulary item schema lives in [docs/vocabulary-item-schema.md](docs/vocabulary-item-schema.md).

--- a/docs/parent-observation.md
+++ b/docs/parent-observation.md
@@ -1,0 +1,41 @@
+# Parent Observation Features
+
+## Status
+Proposed
+
+## Purpose
+Define the smallest planning slice that lets a parent notice whether the learner is progressing later, while keeping the first version aligned with the child-focused learning loop.
+
+## Scope
+
+- This planning pass covers only lightweight parent observation ideas that can be derived from the learner's normal stage and review outcomes.
+- The goal is to make later progress visibility easier to design, not to add parent-facing accounts, notifications, dashboards, or cross-device syncing in v1.
+- The scope should stay compatible with [docs/learn-mode.md](learn-mode.md), [docs/review-loop.md](review-loop.md), and the browser-first assumptions already documented elsewhere in the repo.
+
+## Candidate v1 Progress Metrics
+
+- `stages started` gives a simple sign that the learner is entering practice sessions at all.
+- `stages completed` gives the clearest lightweight signal that the learner is finishing short learning loops instead of abandoning them early.
+- `weak words still active` gives a compact view of whether the current stage ended with unresolved recovery items that may need more practice later.
+- `clean first-pass items versus supported clears` gives a rough distinction between confident recall and progress that still needed help, without introducing a full mastery model.
+- `most recent practice date` gives a parent a basic recency signal without requiring streak pressure, attendance rules, or scheduled reminders.
+
+## V1 Planning Scope
+
+- V1 should treat these metrics as planning outputs that can be summarized from existing run results without requiring a parent account.
+- V1 should avoid permanent learner profiles, new schema fields, or any server-authored reporting pipeline, and should remain usable without assuming a backend.
+- V1 should stay stage-sized and session-sized: a parent needs a lightweight sense of whether practice happened and whether the learner finished or still has weak words to revisit.
+- V1 should prefer simple labels and counts over comparative scores, rankings, or dense analytics because the child-focused learning loop remains the core product surface.
+- V1 should not force new gameplay branches, teacher-style grading language, or interruptive approval flows inside the learner session.
+
+## Later Product Ideas
+
+- Later work may add durable history across sessions, pack-level rollups, and longer-term trend summaries once the base loop is proven.
+- Later work may add parent-facing summaries of repeated weak words, practice consistency, or celebration moments after the runtime and data model are stable.
+- Later work may explore shareable reports, notifications, or family account views, but only after the product intentionally decides how identity, privacy, and retention should work.
+- Later work may define stronger mastery or readiness signals, but those should extend the existing stage and review outcomes rather than replace them with a separate scoring system too early.
+
+## Review Boundary
+
+- This planning doc is complete enough for the current phase when it names a small set of candidate metrics, separates v1 planning scope from later product ideas, and stays compatible with the current child-focused learning loop.
+- Review should confirm that parent observation remains intentionally minimal, does not require new infrastructure assumptions, and does not overtake the learner-facing gameplay priorities.

--- a/scripts/check-parent-observation.sh
+++ b/scripts/check-parent-observation.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+doc="$script_dir/../docs/parent-observation.md"
+readme="$script_dir/../README.md"
+
+[ -f "$doc" ] || {
+  printf 'missing required file: %s\n' "$doc" >&2
+  exit 1
+}
+
+[ -f "$readme" ] || {
+  printf 'missing required file: %s\n' "$readme" >&2
+  exit 1
+}
+
+check_doc() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$doc"; then
+    printf 'missing required parent observation content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_readme() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$readme"; then
+    printf 'missing README parent observation pointer: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_doc "Parent Observation Features"
+check_doc "Candidate v1 Progress Metrics"
+check_doc "V1 Planning Scope"
+check_doc "Later Product Ideas"
+check_doc "Review Boundary"
+check_doc "stages started"
+check_doc "stages completed"
+check_doc "weak words still active"
+check_doc "without requiring a parent account"
+check_doc "without assuming a backend"
+check_doc "child-focused learning loop"
+check_readme "docs/parent-observation.md"
+
+printf 'Parent observation check passed\n'


### PR DESCRIPTION
## Summary\n- add a focused validation script for the parent observation planning spec\n- add a minimal parent observation planning doc with v1 metrics and later-scope separation\n- link the new spec from the README\n\n## Testing\n- sh scripts/check-parent-observation.sh\n\nCloses #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added parent observation feature documentation, defining v1 scope and constraints for lightweight parent visibility using existing learner metrics.
  * Clarified that v1 will exclude parent accounts, notifications, dashboards, and new schema changes, with expanded capabilities planned for future releases.
  * Updated project documentation to reference parent observation specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->