### PR TITLE
Epic 6.1 - Define milestone roadmap from docs to PoC

### DIFF
--- a/.codex-supervisor/issues/45/issue-journal.md
+++ b/.codex-supervisor/issues/45/issue-journal.md
@@ -1,0 +1,37 @@
+# Issue #45: Epic 6.1 - Define milestone roadmap from docs to PoC
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/FNE/issues/45
+- Branch: codex/issue-45
+- Workspace: .
+- Journal: .codex-supervisor/issues/45/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: f15fdc00fcdb2945a2b392deaac7e11913c96efd
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-10T14:08:38.629Z
+
+## Latest Codex Summary
+- Added `docs/milestone-roadmap.md` as a staged delivery plan from planning docs to the first browser PoC.
+- Added `scripts/check-milestone-roadmap.sh` to enforce milestone order and explicit exit-criteria sections.
+- Updated `README.md` to link the roadmap from the top-level planning doc list.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The primary gap was the absence of a roadmap artifact and a focused validation check proving its required structure.
+- What changed: Added the roadmap doc, added a focused shell check for its sequence and exit criteria, and linked the roadmap from `README.md`.
+- Current blocker: none
+- Next exact step: Stage the roadmap files and issue journal, commit the checkpoint, and leave the branch ready for review or PR creation.
+- Verification gap: No broader doc-suite aggregation script was run because this issue only changed roadmap discoverability and its dedicated check.
+- Files touched: README.md; docs/milestone-roadmap.md; scripts/check-milestone-roadmap.sh; .codex-supervisor/issues/45/issue-journal.md
+- Rollback concern: Low; the change is additive and isolated to docs plus one shell check.
+- Last focused command: sh scripts/check-milestone-roadmap.sh
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- Reproduced failure first by running `sh scripts/check-milestone-roadmap.sh` before the roadmap existed; it failed on missing `docs/milestone-roadmap.md`.
+- Focused verification after implementation: `sh scripts/check-milestone-roadmap.sh` and `sh scripts/check-product-brief.sh`.

--- a/.codex-supervisor/issues/45/issue-journal.md
+++ b/.codex-supervisor/issues/45/issue-journal.md
@@ -17,6 +17,7 @@
 - Added `docs/milestone-roadmap.md` as a staged delivery plan from planning docs to the first browser PoC.
 - Added `scripts/check-milestone-roadmap.sh` to enforce milestone order and explicit exit-criteria sections.
 - Updated `README.md` to link the roadmap from the top-level planning doc list.
+- Pushed `codex/issue-45` and opened draft PR #49: https://github.com/TommyKammy/FNE/pull/49
 
 ## Active Failure Context
 - None recorded.
@@ -24,13 +25,13 @@
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: The primary gap was the absence of a roadmap artifact and a focused validation check proving its required structure.
-- What changed: Added the roadmap doc, added a focused shell check for its sequence and exit criteria, and linked the roadmap from `README.md`.
+- What changed: Added the roadmap doc, added a focused shell check for its sequence and exit criteria, linked the roadmap from `README.md`, pushed the branch, and opened draft PR #49.
 - Current blocker: none
-- Next exact step: Stage the roadmap files and issue journal, commit the checkpoint, and leave the branch ready for review or PR creation.
+- Next exact step: Wait for draft PR review or convert the draft once the roadmap wording is accepted.
 - Verification gap: No broader doc-suite aggregation script was run because this issue only changed roadmap discoverability and its dedicated check.
 - Files touched: README.md; docs/milestone-roadmap.md; scripts/check-milestone-roadmap.sh; .codex-supervisor/issues/45/issue-journal.md
 - Rollback concern: Low; the change is additive and isolated to docs plus one shell check.
-- Last focused command: sh scripts/check-milestone-roadmap.sh
+- Last focused command: gh pr create --draft --base main --head codex/issue-45 --title "Epic 6.1 - Define milestone roadmap from docs to PoC" --body ...
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
 - Reproduced failure first by running `sh scripts/check-milestone-roadmap.sh` before the roadmap existed; it failed on missing `docs/milestone-roadmap.md`.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ FNE stands for Friday Night English.
 ## Repository Layout
 The initial monorepo shape is documented in [docs/repo-boundaries.md](docs/repo-boundaries.md).
 The planning glossary for shared issue vocabulary lives in [docs/planning-glossary.md](docs/planning-glossary.md).
+The staged delivery plan from planning docs to the first browser PoC lives in [docs/milestone-roadmap.md](docs/milestone-roadmap.md).
 The Learn Mode behavior spec lives in [docs/learn-mode.md](docs/learn-mode.md).
 The review and weak-word loop spec lives in [docs/review-loop.md](docs/review-loop.md).
 The Battle Mode behavior spec lives in [docs/battle-mode.md](docs/battle-mode.md).

--- a/docs/milestone-roadmap.md
+++ b/docs/milestone-roadmap.md
@@ -1,0 +1,67 @@
+# Milestone Roadmap from Planning Docs to First PoC
+
+## Intent
+This roadmap turns the current planning draft into a delivery sequence that can move FNE from documentation to a first browser-playable proof of concept.
+
+The order stays aligned with the current planning stack:
+
+- foundation and shared rules before implementation commitments
+- content and repository contracts before runtime integration
+- Learn Mode before later practice and pressure modes
+- Listen & Match Mode and Battle Mode before parent-facing interpretation of results
+- Parent Observation Features only after learner outcomes exist to summarize
+
+## Milestone 1 - Planning Baseline Locked
+Lock the project-wide planning rules that every later milestone depends on.
+
+### Exit Criteria
+- The team agrees on the product thesis and first-wave learner goals from `README.md`.
+- The repository shape in `docs/repo-boundaries.md` is accepted as the working boundary for `apps/`, `packages/`, and `content/`.
+- Shared planning language from `docs/planning-glossary.md` is stable enough to reuse in implementation tickets without term drift.
+- The Architecture Decision Record: Browser-First Stack in `docs/architecture.md` remains the active implementation baseline.
+- `docs/ux-rules.md`, `docs/accessibility-baseline.md`, and Validation Gates in `docs/validation-gates.md` are treated as required review gates for later UI and implementation work.
+
+## Milestone 2 - Content and Runtime Contracts Locked
+Freeze the authoring contracts that let runtime work proceed without inventing new data rules mid-build.
+
+### Exit Criteria
+- The canonical content contracts for vocabulary items, packs, stages, and mod boundaries are clear enough to author one playable pack without schema guessing.
+- `docs/vocabulary-item-schema.md`, `docs/pack-schema.md`, `docs/stage-schema.md`, and `docs/mod-contract.md` define the required fields and ownership boundaries for first-wave content.
+- `docs/asset-conventions.md` is explicit enough for art and audio references to be added without path or naming ambiguity.
+- The contract between content data and engine code still follows the repository and architecture boundaries instead of embedding lesson data in runtime logic.
+- A contributor can identify what must exist to load one browser-playable stage from content files alone.
+
+## Milestone 3 - Learn Mode Vertical Slice Playable
+Deliver the first complete learner-facing slice around the guided image-plus-audio teaching loop.
+
+### Exit Criteria
+- One browser-playable stage can run the Learn Mode reveal order from `docs/learn-mode.md` from start to summary.
+- The playable slice uses the Browser-First Stack from `docs/architecture.md`, including the React shell around gameplay and the Phaser-owned moment-to-moment play scene.
+- The stage demonstrates the image-first, pronunciation-backed teaching flow described in `README.md`.
+- The slice respects the core readability, keyboard-first, visible-state, and audio-fallback expectations from `docs/accessibility-baseline.md`.
+- The team can review the slice as the first playable demo even if later modes and progression systems are still stubbed or absent.
+
+## Milestone 4 - Stage Loop Expansion Ready
+Extend the first slice into a short but complete learning loop that can teach, recheck, and pressure-test the same stage content.
+
+### Exit Criteria
+- Listen & Match Mode is defined well enough in `docs/listen-and-match-mode.md` to run pronunciation-first recognition on the same pack content used by Learn Mode.
+- Battle Mode is defined well enough in `docs/battle-mode.md` to pressure-test previously exposed vocabulary in a browser-first stage flow.
+- The Review and Weak-Word Loop in `docs/review-loop.md` closes the stage by resurfacing weak words after the first pass instead of dropping unresolved items.
+- Stage outcomes can distinguish clean clears, supported clears, and unresolved weak words without inventing a separate product thesis.
+- The intended stage sequence is now clear: guided exposure first, recognition follow-up second, higher-pressure rhythm challenge third, short review closure last.
+
+## Milestone 5 - Browser PoC Ready for First External Playtest
+Package the planned learning loop into a coherent first proof of concept that can be shared and judged outside the planning circle.
+
+### Exit Criteria
+- The browser PoC covers one end-to-end learner loop from entry to completion using the accepted browser-first architecture.
+- Parent Observation Features are limited to lightweight summaries derived from stage results, consistent with `docs/parent-observation.md`.
+- The PoC is reviewable as a delivery plan outcome rather than a codebase sketch: what is playable, what is observable, and what remains intentionally deferred are all explicit.
+- The verification language for implementation tickets can reuse the `typecheck` and `lint` gate names from `docs/validation-gates.md`.
+- The team can schedule first external playtests with a shared understanding of what must be true before the PoC counts as ready.
+
+## Review Notes
+- This roadmap keeps the first playable milestone narrower than the full PoC so the project can validate the guided loop before expanding scope.
+- It preserves the current epic direction by keeping Learn Mode ahead of later recognition and battle work, and by keeping Parent Observation Features downstream of learner-facing outcomes.
+- It keeps the plan anchored to existing docs instead of inventing a new implementation architecture beyond the accepted Browser-First Stack and current planning rules.

--- a/scripts/check-milestone-roadmap.sh
+++ b/scripts/check-milestone-roadmap.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+file="$script_dir/../docs/milestone-roadmap.md"
+
+check() {
+  pattern="$1"
+  if ! grep -Fq "$pattern" "$file"; then
+    printf 'missing required milestone roadmap content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check "# Milestone Roadmap from Planning Docs to First PoC"
+check "## Milestone 1 - Planning Baseline Locked"
+check "## Milestone 2 - Content and Runtime Contracts Locked"
+check "## Milestone 3 - Learn Mode Vertical Slice Playable"
+check "## Milestone 4 - Stage Loop Expansion Ready"
+check "## Milestone 5 - Browser PoC Ready for First External Playtest"
+check "### Exit Criteria"
+check "Learn Mode"
+check "Listen & Match Mode"
+check "Battle Mode"
+check "Parent Observation Features"
+check "Validation Gates"
+check "Architecture Decision Record: Browser-First Stack"
+
+line_number() {
+  pattern="$1"
+  grep -nF "$pattern" "$file" | head -n 1 | cut -d: -f1
+}
+
+m1=$(line_number "## Milestone 1 - Planning Baseline Locked")
+m2=$(line_number "## Milestone 2 - Content and Runtime Contracts Locked")
+m3=$(line_number "## Milestone 3 - Learn Mode Vertical Slice Playable")
+m4=$(line_number "## Milestone 4 - Stage Loop Expansion Ready")
+m5=$(line_number "## Milestone 5 - Browser PoC Ready for First External Playtest")
+
+if [ "$m1" -ge "$m2" ] || [ "$m2" -ge "$m3" ] || [ "$m3" -ge "$m4" ] || [ "$m4" -ge "$m5" ]; then
+  printf 'milestone roadmap headings are out of order\n' >&2
+  exit 1
+fi
+
+exit_count=$(grep -c '^### Exit Criteria$' "$file")
+if [ "$exit_count" -ne 5 ]; then
+  printf 'expected 5 exit criteria sections, found %s\n' "$exit_count" >&2
+  exit 1
+fi
+
+printf 'milestone roadmap check passed\n'


### PR DESCRIPTION
## Summary
- add a staged roadmap from planning docs to the first browser PoC
- add a focused shell check that enforces milestone order and explicit exit criteria
- link the roadmap from the README planning doc index

## Verification
- sh scripts/check-milestone-roadmap.sh
- sh scripts/check-product-brief.sh

Refs #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a structured milestone roadmap outlining the delivery progression from planning documentation to a browser-based proof-of-concept, including five milestones with defined exit criteria.
  * Updated README to reference the new roadmap documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->