### PR TITLE
Define issue template style

### DIFF
--- a/.codex-supervisor/issues/46/issue-journal.md
+++ b/.codex-supervisor/issues/46/issue-journal.md
@@ -5,30 +5,45 @@
 - Branch: codex/issue-46
 - Workspace: .
 - Journal: .codex-supervisor/issues/46/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 6cea4cb326aa505547d0796465d53a419c5c6bce
+- Current phase: addressing_review
+- Attempt count: 3 (implementation=2, repair=1)
+- Last head SHA: 761bbe1864f5b0c1155852172ffdb774fa39344d
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-10T14:21:19.189Z
+- Last failure signature: PRRT_kwDOR-A-2M56KIOg
+- Repeated failure signature count: 1
+- Updated at: 2026-04-10T14:32:59.058Z
 
 ## Latest Codex Summary
-- Added a focused reproducer `sh scripts/check-issue-template-style.sh`, confirmed the repo was missing the issue-template spec and reusable GitHub templates, then implemented the missing doc, epic template, child issue template, and README pointer. Focused verification now passes.
+Pushed `codex/issue-46` and opened draft PR [#50](https://github.com/TommyKammy/FNE/pull/50) against `main`. The GitHub app could not create the PR because of integration permissions, so I used `gh` as fallback and updated the issue journal handoff to reflect the live PR state and remaining verification gap.
+
+Summary: Pushed the committed issue-template changes and opened draft PR #50; updated the journal handoff to the live `pr_open` state.
+State hint: pr_open
+Blocked reason: none
+Tests: `gh pr view 50 --json number,url,state,isDraft,headRefName,baseRefName`; previously verified with `sh scripts/check-issue-template-style.sh`, `sh scripts/check-planning-glossary.sh`, `sh scripts/check-validation-gates.sh`
+Next action: Monitor draft PR #50 for review or requested changes, then address feedback or mark it ready for review.
+Failure signature: PRRT_kwDOR-A-2M56KIOg
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 1 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/FNE/pull/50#discussion_r3064907030
+- Details:
+  - scripts/check-issue-template-style.sh:32 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Add explicit README file existence validation before content checks.** Line 55 checks README content, but README presence is never validated ... url=https://github.com/TommyKammy/FNE/pull/50#discussion_r3064907030
 
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: The issue is a missing repository standard for future implementation-ticket structure, best fixed by following the repo's existing doc-plus-check pattern.
-- What changed: Added `docs/issue-template-style.md`, `.github/ISSUE_TEMPLATE/epic.md`, `.github/ISSUE_TEMPLATE/implementation-ticket.md`, `scripts/check-issue-template-style.sh`, and a README pointer to the new spec.
+- What changed: Added `docs/issue-template-style.md`, `.github/ISSUE_TEMPLATE/epic.md`, `.github/ISSUE_TEMPLATE/implementation-ticket.md`, `scripts/check-issue-template-style.sh`, and a README pointer to the new spec; committed as `761bbe1`; pushed `codex/issue-46`; opened draft PR #50.
 - Current blocker: none
-- Next exact step: Stage the new files, commit the checkpoint on `codex/issue-46`, and decide whether to open a draft PR.
-- Verification gap: No broader CI exists; only focused shell-doc checks were run locally.
-- Files touched: README.md, docs/issue-template-style.md, .github/ISSUE_TEMPLATE/epic.md, .github/ISSUE_TEMPLATE/implementation-ticket.md, scripts/check-issue-template-style.sh
+- Next exact step: Commit and push the review-thread fix for `scripts/check-issue-template-style.sh`, then monitor PR #50 for updated review state.
+- Verification gap: No broader CI exists; the review fix is covered by focused local shell checks only.
+- Files touched: README.md, docs/issue-template-style.md, .github/ISSUE_TEMPLATE/epic.md, .github/ISSUE_TEMPLATE/implementation-ticket.md, scripts/check-issue-template-style.sh, .codex-supervisor/issues/46/issue-journal.md
 - Rollback concern: Low; the change only adds documentation, templates, and a focused verification script.
-- Last focused command: sh scripts/check-issue-template-style.sh
+- Last focused command: `sh scripts/check-issue-template-style.sh`
 ### Scratchpad
 - Reproducer before fix: `sh scripts/check-issue-template-style.sh` failed with `missing issue template style doc`.
 - Verification after fix: `sh scripts/check-issue-template-style.sh`, `sh scripts/check-planning-glossary.sh`, `sh scripts/check-validation-gates.sh`.
+- PR status: draft PR #50 open against `main` from `codex/issue-46`.
+- Review finding validated: CodeRabbit thread `PRRT_kwDOR-A-2M56KIOg` is valid because the checker asserted README content without first verifying README existence.
+- Review fix applied: added `check_file "$readme" "README"` before the README content assertion in `scripts/check-issue-template-style.sh`.
+- Review verification: `sh scripts/check-issue-template-style.sh`; temp-directory negative test with missing `README.md` now fails as `missing README: .../README.md`.

--- a/.codex-supervisor/issues/46/issue-journal.md
+++ b/.codex-supervisor/issues/46/issue-journal.md
@@ -1,0 +1,34 @@
+# Issue #46: Epic 6.2 - Define issue template style for this repo
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/FNE/issues/46
+- Branch: codex/issue-46
+- Workspace: .
+- Journal: .codex-supervisor/issues/46/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 6cea4cb326aa505547d0796465d53a419c5c6bce
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-10T14:21:19.189Z
+
+## Latest Codex Summary
+- Added a focused reproducer `sh scripts/check-issue-template-style.sh`, confirmed the repo was missing the issue-template spec and reusable GitHub templates, then implemented the missing doc, epic template, child issue template, and README pointer. Focused verification now passes.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The issue is a missing repository standard for future implementation-ticket structure, best fixed by following the repo's existing doc-plus-check pattern.
+- What changed: Added `docs/issue-template-style.md`, `.github/ISSUE_TEMPLATE/epic.md`, `.github/ISSUE_TEMPLATE/implementation-ticket.md`, `scripts/check-issue-template-style.sh`, and a README pointer to the new spec.
+- Current blocker: none
+- Next exact step: Stage the new files, commit the checkpoint on `codex/issue-46`, and decide whether to open a draft PR.
+- Verification gap: No broader CI exists; only focused shell-doc checks were run locally.
+- Files touched: README.md, docs/issue-template-style.md, .github/ISSUE_TEMPLATE/epic.md, .github/ISSUE_TEMPLATE/implementation-ticket.md, scripts/check-issue-template-style.sh
+- Rollback concern: Low; the change only adds documentation, templates, and a focused verification script.
+- Last focused command: sh scripts/check-issue-template-style.sh
+### Scratchpad
+- Reproducer before fix: `sh scripts/check-issue-template-style.sh` failed with `missing issue template style doc`.
+- Verification after fix: `sh scripts/check-issue-template-style.sh`, `sh scripts/check-planning-glossary.sh`, `sh scripts/check-validation-gates.sh`.

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,25 @@
+---
+name: Epic
+about: Plan a parent issue that groups a reusable slice of work.
+title: "Epic X - "
+labels: []
+assignees: []
+---
+
+## Summary
+- State the user-facing outcome or planning goal the epic unlocks.
+
+## Scope
+- List what belongs inside this epic boundary.
+- Keep this focused on planning scope, not implementation sequencing.
+
+## Child Issues
+- #<child-issue-number> - <child issue title>
+
+## Acceptance Criteria
+- the epic scope is explicit enough for child issues to inherit without reinterpretation
+- the child issue list covers the intended slice of work without mixing in out-of-scope items
+- the epic can be reviewed for completeness from the issue text alone
+
+## Verification
+- review the epic issue body and confirm the summary, scope, child issue list, and acceptance criteria are unambiguous

--- a/.github/ISSUE_TEMPLATE/implementation-ticket.md
+++ b/.github/ISSUE_TEMPLATE/implementation-ticket.md
@@ -1,0 +1,26 @@
+---
+name: Implementation Ticket
+about: Plan one implementation issue under an epic with reusable metadata and reviewable outcomes.
+title: "Feature - "
+labels: []
+assignees: []
+---
+
+Part of: #<epic-number>
+Depends on: #<issue-number or none>
+Parallelizable: <Yes|No>
+
+## Summary
+- State the single change this ticket delivers.
+
+## Scope
+- List the files, docs, interfaces, or behavior surfaces that belong in this ticket.
+- Keep implementation notes out of the planning structure unless they define scope boundaries.
+
+## Acceptance Criteria
+- describe observable end states only
+- make each criterion reviewable from diffs alone
+- use repository terminology from the planning glossary and validation gates where applicable
+
+## Verification
+- list the focused review steps, scripts, or gates needed to confirm the ticket outcome

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ FNE stands for Friday Night English.
 ## Repository Layout
 The initial monorepo shape is documented in [docs/repo-boundaries.md](docs/repo-boundaries.md).
 The planning glossary for shared issue vocabulary lives in [docs/planning-glossary.md](docs/planning-glossary.md).
+The issue template style for future epics and implementation tickets lives in [docs/issue-template-style.md](docs/issue-template-style.md).
 The staged delivery plan from planning docs to the first browser PoC lives in [docs/milestone-roadmap.md](docs/milestone-roadmap.md).
 The Learn Mode behavior spec lives in [docs/learn-mode.md](docs/learn-mode.md).
 The review and weak-word loop spec lives in [docs/review-loop.md](docs/review-loop.md).

--- a/docs/issue-template-style.md
+++ b/docs/issue-template-style.md
@@ -1,0 +1,74 @@
+# Issue Template Style
+
+## Purpose
+Use these templates for future planning and implementation tickets so issue structure stays consistent, acceptance criteria can be reviewed from diffs alone, and codex-supervisor execution metadata remains easy to parse.
+
+Keep the planning-ticket structure focused on intent, scope, dependencies, and reviewable outcomes. Authors should avoid mixing implementation detail into planning-ticket structure. Implementation approach belongs in later execution notes, comments, commits, or pull requests.
+
+## Epic Template
+Use the epic template for a parent issue that defines one reusable slice of work and links the child issues that will deliver it.
+
+Required sections:
+
+- `## Summary` for the user-facing outcome the epic is trying to unlock.
+- `## Scope` for what belongs inside the epic boundary.
+- `## Child Issues` for the planned implementation tickets that roll up to the epic.
+- `## Acceptance Criteria` for the minimum set of reviewable outcomes the epic must satisfy.
+- `## Verification` for the review pass that confirms the epic is ready to break into or assess through child tickets.
+
+Epic issues should describe the planning boundary, not the implementation sequence inside each child ticket.
+
+## Child Issue Template
+Use the child issue template for one implementation ticket that can be assigned, verified, and closed on its own.
+
+Required metadata lines:
+
+- `Part of:` for the parent epic number.
+- `Depends on:` for prerequisite tickets when order matters.
+- `Parallelizable:` for whether another ticket can safely proceed at the same time.
+
+Required sections:
+
+- `## Summary` for the single change the ticket makes.
+- `## Scope` for the concrete boundary of work that belongs in the ticket.
+- `## Acceptance Criteria` for the observable outcomes that must be true after the change.
+- `## Verification` for the focused checks or review steps needed to confirm the ticket outcome.
+
+Child issues should stay outcome-first. They can mention required interfaces, files, or documents, but they should not turn into an implementation diary.
+
+## Acceptance Criteria Style
+Acceptance criteria must be specific enough to be reviewed from diffs alone.
+
+Use these rules:
+
+- Write each criterion as an observable end state, not as an instruction to perform a task.
+- Name the artifact or surface that changes, such as a doc, script, config file, or template.
+- Prefer repository language already defined in the planning glossary and validation gates.
+- Reuse stable gate names such as `typecheck` and `lint` when the criterion depends on them.
+- Avoid vague phrasing like `supports`, `handles`, `improves`, or `works better` unless the diff itself can prove the claim.
+- Avoid embedding step-by-step implementation detail in the criterion text.
+
+Good criterion examples:
+
+- `an epic template exists under .github/ISSUE_TEMPLATE with the required planning sections`
+- `the child issue template includes Part of, Depends on, and Parallelizable metadata lines`
+- `the acceptance criteria guidance says criteria must be reviewable from diffs alone`
+
+Weak criterion examples:
+
+- `implement the template logic`
+- `update things as needed`
+- `make the planning issues clearer`
+
+## Supervisor Alignment
+The template format should stay compatible with codex-supervisor execution metadata expectations.
+
+That means:
+
+- dependency and sequencing fields stay on their own lines
+- acceptance criteria remain easy to scan as flat bullets
+- verification stays separate from scope and acceptance criteria
+- planning structure avoids hiding key metadata inside prose paragraphs
+
+## Reuse Rule
+Future issue authors should start from these templates instead of inventing new planning layouts for each ticket. If the project later needs new standard fields, update this document and the template files together.

--- a/scripts/check-issue-template-style.sh
+++ b/scripts/check-issue-template-style.sh
@@ -29,6 +29,7 @@ check_contains() {
 check_file "$doc" "issue template style doc"
 check_file "$epic_template" "epic issue template"
 check_file "$child_template" "child issue template"
+check_file "$readme" "README"
 
 check_contains "$doc" "Issue Template Style" "issue template style doc"
 check_contains "$doc" "Epic Template" "issue template style doc"

--- a/scripts/check-issue-template-style.sh
+++ b/scripts/check-issue-template-style.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+doc="$script_dir/../docs/issue-template-style.md"
+readme="$script_dir/../README.md"
+epic_template="$script_dir/../.github/ISSUE_TEMPLATE/epic.md"
+child_template="$script_dir/../.github/ISSUE_TEMPLATE/implementation-ticket.md"
+
+check_file() {
+  path="$1"
+  label="$2"
+  if [ ! -f "$path" ]; then
+    printf 'missing %s: %s\n' "$label" "$path" >&2
+    exit 1
+  fi
+}
+
+check_contains() {
+  path="$1"
+  pattern="$2"
+  label="$3"
+  if ! grep -Fq "$pattern" "$path"; then
+    printf 'missing %s content: %s\n' "$label" "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_file "$doc" "issue template style doc"
+check_file "$epic_template" "epic issue template"
+check_file "$child_template" "child issue template"
+
+check_contains "$doc" "Issue Template Style" "issue template style doc"
+check_contains "$doc" "Epic Template" "issue template style doc"
+check_contains "$doc" "Child Issue Template" "issue template style doc"
+check_contains "$doc" "Acceptance Criteria Style" "issue template style doc"
+check_contains "$doc" "reviewed from diffs alone" "issue template style doc"
+check_contains "$doc" "codex-supervisor execution metadata" "issue template style doc"
+check_contains "$doc" "avoid mixing implementation detail" "issue template style doc"
+
+check_contains "$epic_template" "## Summary" "epic template"
+check_contains "$epic_template" "## Scope" "epic template"
+check_contains "$epic_template" "## Child Issues" "epic template"
+check_contains "$epic_template" "## Acceptance Criteria" "epic template"
+check_contains "$epic_template" "## Verification" "epic template"
+
+check_contains "$child_template" "## Summary" "child template"
+check_contains "$child_template" "## Scope" "child template"
+check_contains "$child_template" "## Acceptance Criteria" "child template"
+check_contains "$child_template" "## Verification" "child template"
+check_contains "$child_template" "Part of:" "child template"
+check_contains "$child_template" "Depends on:" "child template"
+check_contains "$child_template" "Parallelizable:" "child template"
+
+check_contains "$readme" "docs/issue-template-style.md" "README"
+
+printf 'Issue template style check passed\n'


### PR DESCRIPTION
## Summary
- add a repository issue-template style spec for future epics and implementation tickets
- add reusable GitHub issue templates for epic and child implementation issues
- add a focused shell check and README pointer for the new standard

## Verification
- sh scripts/check-issue-template-style.sh
- sh scripts/check-planning-glossary.sh
- sh scripts/check-validation-gates.sh

Closes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added standardized GitHub issue templates for epics and implementation tickets to improve planning and reviewability.
  * Added an issue-template style guide describing required sections, wording guidance, and reuse rules.
  * Updated the README to reference the new style guide.
  * Recorded an internal issue journal entry documenting PR/handoff status and an active review note.

* **Chores**
  * Added an automated verification script to ensure templates and docs conform to the style guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->