### PR TITLE
Epic 6.3: define QA strategy for content and gameplay logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The pack schema lives in [docs/pack-schema.md](docs/pack-schema.md).
 The stage schema lives in [docs/stage-schema.md](docs/stage-schema.md).
 The mod contract lives in [docs/mod-contract.md](docs/mod-contract.md).
 The asset conventions live in [docs/asset-conventions.md](docs/asset-conventions.md).
+The QA strategy for content validation and gameplay verification lives in [docs/qa-strategy.md](docs/qa-strategy.md).
 The TypeScript usage policy lives in [docs/typescript-policy.md](docs/typescript-policy.md).
 The draft TypeScript compiler baseline lives in [docs/typescript-baseline.md](docs/typescript-baseline.md).
 The TypeScript compatibility review checklist lives in [docs/typescript-review-checklist.md](docs/typescript-review-checklist.md).

--- a/docs/milestone-roadmap.md
+++ b/docs/milestone-roadmap.md
@@ -59,6 +59,7 @@ Package the planned learning loop into a coherent first proof of concept that ca
 - Parent Observation Features are limited to lightweight summaries derived from stage results, consistent with `docs/parent-observation.md`.
 - The PoC is reviewable as a delivery plan outcome rather than a codebase sketch: what is playable, what is observable, and what remains intentionally deferred are all explicit.
 - The verification language for implementation tickets can reuse the `typecheck` and `lint` gate names from `docs/validation-gates.md`.
+- `docs/qa-strategy.md` separates content QA, gameplay QA, and first-playable manual playtest expectations well enough to guide later verification work.
 - The team can schedule first external playtests with a shared understanding of what must be true before the PoC counts as ready.
 
 ## Review Notes

--- a/docs/qa-strategy.md
+++ b/docs/qa-strategy.md
@@ -1,0 +1,75 @@
+# QA Strategy for Content and Gameplay Logic
+
+## Status
+Proposed
+
+## Purpose
+Define how first-wave QA should cover content schemas, asset validity, and gameplay behavior without blurring authoring errors into runtime logic bugs.
+
+This strategy is written for the planning-stage repo structure, where `docs/` defines contracts first and later implementation work can attach concrete validators and automated tests to the same boundaries.
+
+## Scope Separation
+
+- Content QA proves that authored data is valid before runtime logic tries to use it.
+- Gameplay QA proves that mode rules, scoring, timing, and learner feedback behave correctly when valid content is already loaded.
+- Asset validity is treated as content QA because missing or mismatched files are authoring failures, not gameplay behavior failures.
+- Manual playtesting is used to judge first-playable learner flow and feedback quality, not to replace schema validation or logic tests.
+
+## Schema Validation for Content Files
+
+- Treat `docs/vocabulary-item-schema.md`, `docs/pack-schema.md`, and `docs/stage-schema.md` as the source contracts for content validation.
+- Validate vocabulary item shape first, then pack-level structure, then stage references and unlock/pass metadata.
+- Reject unknown fields at the schema boundary so content drift is caught before implementation code compensates for it.
+- Validate cross-file references separately from gameplay logic:
+  - vocabulary item ids referenced by stages must exist
+  - declared asset ids must resolve through the asset rules in `docs/asset-conventions.md`
+  - pack and stage manifests must stay compatible with the published schema version rules
+- Keep schema validation deterministic and data-only so the same checks can run in CI, local authoring review, or mod intake later.
+
+## Content QA
+
+- Primary goal: prove that authored lesson data is structurally valid and complete enough to load safely.
+- Required checks:
+  - schema validation for vocabulary items, packs, and stages
+  - asset validity for referenced image and audio files
+  - content-level review that stage ordering, pass thresholds, and unlock metadata are present and internally consistent
+- Failure examples that belong in content QA:
+  - a vocabulary item is missing a required field
+  - a stage references an unknown item id
+  - an `imageAssetId` or `audioAssetId` does not resolve to a pack-local file
+  - a manifest uses unsupported schema metadata
+- Content QA should stop before judging timing windows, score tuning, or mode-specific player feedback.
+
+## Gameplay QA
+
+- Primary goal: prove that gameplay logic behaves correctly once valid content has already passed content QA.
+- Focus automated tests on mode rules and state transitions:
+  - Learn Mode reveal order and completion flow
+  - Listen & Match answer resolution, distractor handling, and retry behavior
+  - Battle Mode judgment, streak, fail state, and recovery rules
+  - review-loop promotion of weak words and stage outcome summaries
+- Failure examples that belong in gameplay QA:
+  - the wrong answer is accepted as correct
+  - score or accuracy thresholds are applied incorrectly
+  - review logic fails to resurface weak words
+  - UI feedback or state progression disagrees with the documented mode rules
+- Gameplay QA should assume fixtures already satisfy the content schemas so tests stay separate from gameplay logic concerns.
+
+## Manual Playtest Expectations
+
+- Manual playtests are required for first-playable work even when schema and gameplay checks pass.
+- A first-playable playtest should confirm:
+  - the learner can start and finish one short stage without facilitator translation
+  - image, audio, and prompt timing are understandable on first contact
+  - success, mistake, retry, and completion states are visible enough to follow in real time
+  - the loop feels like one coherent round instead of disconnected screens or debug scaffolding
+- Record manual observations separately from automated pass/fail checks so subjective findings do not weaken hard validation gates.
+- If a manual playtest finds a content comprehension issue, route it to content QA; if it finds a rules or feedback bug, route it to gameplay QA.
+
+## Verification Layers
+
+- Layer 1: schema and asset validation for content files
+- Layer 2: focused automated tests for gameplay logic
+- Layer 3: manual playtest review for first-playable learner experience
+
+This order keeps content failures separate from gameplay logic failures and keeps manual review from becoming the first line of defense for broken data contracts.

--- a/scripts/check-qa-strategy.sh
+++ b/scripts/check-qa-strategy.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+doc="$script_dir/../docs/qa-strategy.md"
+readme="$script_dir/../README.md"
+
+check_doc() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$doc"; then
+    printf 'missing required QA strategy content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_readme() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$readme"; then
+    printf 'missing README QA strategy pointer: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+if [ ! -f "$doc" ]; then
+  printf 'missing QA strategy doc: %s\n' "$doc" >&2
+  exit 1
+fi
+
+check_doc "QA Strategy for Content and Gameplay Logic"
+check_doc "Schema Validation for Content Files"
+check_doc "Content QA"
+check_doc "Gameplay QA"
+check_doc "Manual Playtest Expectations"
+check_doc "first-playable"
+check_doc "asset validity"
+check_doc "separate from gameplay logic"
+check_doc "planning-stage repo structure"
+check_readme "docs/qa-strategy.md"
+
+printf 'QA strategy check passed\n'

--- a/scripts/check-qa-strategy.sh
+++ b/scripts/check-qa-strategy.sh
@@ -26,6 +26,11 @@ if [ ! -f "$doc" ]; then
   exit 1
 fi
 
+if [ ! -f "$readme" ]; then
+  printf 'missing README file: %s\n' "$readme" >&2
+  exit 1
+fi
+
 check_doc "QA Strategy for Content and Gameplay Logic"
 check_doc "Schema Validation for Content Files"
 check_doc "Content QA"


### PR DESCRIPTION
## Summary
- add a dedicated QA strategy planning doc for content schemas, asset validity, and gameplay logic
- separate content QA, gameplay QA, and manual first-playable playtest expectations
- add a focused doc check and wire the new doc into the README and milestone roadmap

## Verification
- ./scripts/check-qa-strategy.sh
- sh scripts/check-milestone-roadmap.sh

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new QA strategy guide outlining content vs. gameplay QA, verification layers, and manual playtest expectations.
  * Updated repository docs to reference the QA strategy guide.
  * Added QA strategy requirements to the project roadmap.

* **Chores**
  * Added a validation script to verify the QA strategy documentation and README reference are present and complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->