### PR TITLE
Define release posture for PoC builds

### DIFF
--- a/.codex-supervisor/issues/48/issue-journal.md
+++ b/.codex-supervisor/issues/48/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #48: Epic 6.4 - Define release posture for PoC builds
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/FNE/issues/48
+- Branch: codex/issue-48
+- Workspace: .
+- Journal: .codex-supervisor/issues/48/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 435e04520b656c095efa3296dea8ec048bb7ce98
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-10T14:56:17.613Z
+
+## Latest Codex Summary
+- Added a dedicated release-posture planning document plus a focused shell check that reproduces the missing-doc failure and now passes.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The issue was a missing planning artifact, not a runtime defect; the narrowest reproducible proof was a focused doc check that failed until release posture language existed.
+- What changed: Added `docs/release-posture.md`, linked it from `README.md`, clarified Milestone 5 wording in `docs/milestone-roadmap.md`, and added `scripts/check-release-posture.sh`.
+- Current blocker: none
+- Next exact step: Stage the documentation and script changes, commit the checkpoint on `codex/issue-48`, and leave the branch ready for PR creation if needed.
+- Verification gap: No broader automation exists for README link integrity beyond the targeted shell checks that now pass.
+- Files touched: `docs/release-posture.md`, `README.md`, `docs/milestone-roadmap.md`, `scripts/check-release-posture.sh`
+- Rollback concern: Low; changes are planning-doc only and the new script is isolated.
+- Last focused command: `sh scripts/check-release-posture.sh`
+### Scratchpad
+- Reproduced failure first with missing `docs/release-posture.md`, then fixed wording mismatch caught by the new check.

--- a/.codex-supervisor/issues/48/issue-journal.md
+++ b/.codex-supervisor/issues/48/issue-journal.md
@@ -14,7 +14,7 @@
 - Updated at: 2026-04-10T14:56:17.613Z
 
 ## Latest Codex Summary
-- Added a dedicated release-posture planning document plus a focused shell check that reproduces the missing-doc failure and now passes.
+- Added a dedicated release-posture planning document plus a focused shell check that reproduced the missing-doc failure and now passes; committed on `codex/issue-48` and opened draft PR #52.
 
 ## Active Failure Context
 - None recorded.
@@ -24,10 +24,10 @@
 - Hypothesis: The issue was a missing planning artifact, not a runtime defect; the narrowest reproducible proof was a focused doc check that failed until release posture language existed.
 - What changed: Added `docs/release-posture.md`, linked it from `README.md`, clarified Milestone 5 wording in `docs/milestone-roadmap.md`, and added `scripts/check-release-posture.sh`.
 - Current blocker: none
-- Next exact step: Stage the documentation and script changes, commit the checkpoint on `codex/issue-48`, and leave the branch ready for PR creation if needed.
+- Next exact step: Wait for review on draft PR #52 and address any wording adjustments if they come back.
 - Verification gap: No broader automation exists for README link integrity beyond the targeted shell checks that now pass.
 - Files touched: `docs/release-posture.md`, `README.md`, `docs/milestone-roadmap.md`, `scripts/check-release-posture.sh`
 - Rollback concern: Low; changes are planning-doc only and the new script is isolated.
-- Last focused command: `sh scripts/check-release-posture.sh`
+- Last focused command: `gh pr create --draft --base main --head codex/issue-48 ...`
 ### Scratchpad
 - Reproduced failure first with missing `docs/release-posture.md`, then fixed wording mismatch caught by the new check.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The initial monorepo shape is documented in [docs/repo-boundaries.md](docs/repo-
 The planning glossary for shared issue vocabulary lives in [docs/planning-glossary.md](docs/planning-glossary.md).
 The issue template style for future epics and implementation tickets lives in [docs/issue-template-style.md](docs/issue-template-style.md).
 The staged delivery plan from planning docs to the first browser PoC lives in [docs/milestone-roadmap.md](docs/milestone-roadmap.md).
+The PoC-era release posture for internal preview builds lives in [docs/release-posture.md](docs/release-posture.md).
 The Learn Mode behavior spec lives in [docs/learn-mode.md](docs/learn-mode.md).
 The review and weak-word loop spec lives in [docs/review-loop.md](docs/review-loop.md).
 The Battle Mode behavior spec lives in [docs/battle-mode.md](docs/battle-mode.md).

--- a/docs/milestone-roadmap.md
+++ b/docs/milestone-roadmap.md
@@ -52,10 +52,11 @@ Extend the first slice into a short but complete learning loop that can teach, r
 - The intended stage sequence is now clear: guided exposure first, recognition follow-up second, higher-pressure rhythm challenge third, short review closure last.
 
 ## Milestone 5 - Browser PoC Ready for First External Playtest
-Package the planned learning loop into a coherent first proof of concept that can be shared and judged outside the planning circle.
+Shape the planned learning loop into a coherent first proof of concept that can be shared and judged outside the planning circle.
 
 ### Exit Criteria
 - The browser PoC covers one end-to-end learner loop from entry to completion using the accepted browser-first architecture.
+- `docs/release-posture.md` defines the internal preview build boundary and PoC-era versioning language without assuming a shipping pipeline yet.
 - Parent Observation Features are limited to lightweight summaries derived from stage results, consistent with `docs/parent-observation.md`.
 - The PoC is reviewable as a delivery plan outcome rather than a codebase sketch: what is playable, what is observable, and what remains intentionally deferred are all explicit.
 - The verification language for implementation tickets can reuse the `typecheck` and `lint` gate names from `docs/validation-gates.md`.

--- a/docs/release-posture.md
+++ b/docs/release-posture.md
@@ -1,0 +1,43 @@
+# Release Posture for PoC Builds
+
+## Intent
+This document defines how FNE should talk about release readiness during the proof-of-concept planning phase.
+
+It exists to separate release posture from packaging or distribution work. The goal is to describe what counts as reviewable progress before the project has a shipping pipeline.
+
+## Internal Preview Build
+An internal preview build is a team-reviewable build of the first browser PoC.
+
+It is meant for contributors and close project reviewers who need to validate the planned learner loop, inspect stage outcomes, and discuss what remains deferred. An internal preview build is not a public launch, store submission, or promise of broad distribution.
+
+For this project, an internal preview build counts as ready when:
+
+- the first browser PoC can run one end-to-end learner loop from entry to completion
+- the build reflects the accepted browser-first architecture and current planning rules
+- reviewers can name what is playable now, what is observable now, and what is intentionally deferred
+- manual playtest review can happen without inventing packaging or release-channel assumptions
+
+## Versioning Expectations
+PoC-era builds should use `0.x` versioning to signal that the project is still validating scope and behavior rather than locking a stable release contract.
+
+Within that range:
+
+- increment the minor version when an internal preview build changes the reviewable learner experience, stage flow, or planning-backed scope in a meaningful way
+- increment the patch version for smaller corrections that do not change the intended release posture of the preview
+- avoid `1.0` language until the team has agreed on a shipping target, support expectations, and a real release pipeline
+
+The version label should help reviewers compare preview snapshots. It does not assume a shipping pipeline, public rollout process, or long-term compatibility promise yet.
+
+## Out of Scope for This Phase
+For this phase, packaging work is out of scope for this release-posture definition.
+
+That means this document does not define:
+
+- installer formats, app-store packaging, or native wrappers
+- release-channel automation, staged rollout rules, or submission checklists
+- distribution promises for external users beyond the planning distinction between internal preview and later external playtest readiness
+
+## Review Notes
+This release posture keeps PoC planning separate from packaging implementation.
+
+It gives the team a shared way to describe internal preview builds and version labels while the project is still proving the first playable browser loop.

--- a/scripts/check-release-posture.sh
+++ b/scripts/check-release-posture.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+file="$script_dir/../docs/release-posture.md"
+
+check() {
+  pattern="$1"
+  if ! grep -Fq "$pattern" "$file"; then
+    printf 'missing required release posture content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+if [ ! -f "$file" ]; then
+  printf 'missing required release posture document: %s\n' "$file" >&2
+  exit 1
+fi
+
+check "# Release Posture for PoC Builds"
+check "## Internal Preview Build"
+check "## Versioning Expectations"
+check "## Out of Scope for This Phase"
+check "internal preview build"
+check "first browser PoC"
+check "0.x"
+check "packaging work is out of scope"
+check "does not assume a shipping pipeline"
+
+printf 'release posture check passed\n'


### PR DESCRIPTION
## Summary
- add a release posture planning doc for PoC-era internal preview builds
- document 0.x versioning expectations without assuming a shipping pipeline
- keep packaging explicitly out of scope and wire in a focused doc check

## Verification
- sh scripts/check-release-posture.sh
- sh scripts/check-milestone-roadmap.sh
- sh scripts/check-architecture-adr.sh

Closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release posture documentation defining readiness criteria, versioning guidance (0.x versions), and internal preview build standards for PoC builds.
  * Updated milestone roadmap with refined objectives and new documentation requirements.
  * Enhanced repository documentation with links to release guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->