### PR TITLE
Epic 7.1 - Define first-launch flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The Listen & Match Mode behavior spec lives in [docs/listen-and-match-mode.md](d
 The parent observation planning spec lives in [docs/parent-observation.md](docs/parent-observation.md).
 The shared visual readability and input simplicity rules live in [docs/ux-rules.md](docs/ux-rules.md).
 The practical accessibility baseline lives in [docs/accessibility-baseline.md](docs/accessibility-baseline.md).
+The minimal launch-to-play contract lives in [docs/first-launch-flow.md](docs/first-launch-flow.md).
 The canonical vocabulary item schema lives in [docs/vocabulary-item-schema.md](docs/vocabulary-item-schema.md).
 The pack schema lives in [docs/pack-schema.md](docs/pack-schema.md).
 The stage schema lives in [docs/stage-schema.md](docs/stage-schema.md).

--- a/docs/first-launch-flow.md
+++ b/docs/first-launch-flow.md
@@ -1,0 +1,41 @@
+# First-Launch Flow
+
+## Status
+Proposed
+
+## Purpose
+Define the minimal learner path from opening the browser app to the first meaningful response so later UI and gameplay work do not reintroduce setup friction.
+
+## Launch Goal
+
+- The learner should be able to reach the first interaction in one action after the app loads.
+- The launch path should require no setup, no account creation, no calibration, and no pack or mode selection before play begins.
+- The first screen should present a single primary action that moves the learner directly into gameplay.
+
+## Entry Sequence
+
+1. The app opens on a launch surface that explains the immediate goal in plain language and shows one obvious start control.
+2. The learner activates that single primary action once and the default first stage begins immediately.
+3. The learner lands on the first item without any intermediate menu, setup form, settings screen, or confirmation modal.
+
+This keeps the reviewable step sequence under 3 steps because the learner only needs to load the app and take one action before the first item is active.
+
+## Transition to the First Item
+
+- The default stage should load with the same assumptions every time so first-launch behavior stays predictable for playtests and implementation work.
+- The transition should carry the learner directly into gameplay instead of stopping on a mode picker, stage map, or tutorial branch.
+- The first item should appear as soon as the stage is ready, with the image-first cue and supporting pronunciation available in the active play surface.
+- The learner should be able to tell what to do first before any timing window or answer deadline begins.
+
+## Menu and Setup Constraints
+
+- Settings, profile controls, or content-selection menus should not block the first run.
+- If settings are visible on the launch surface, they must stay secondary to the single primary action and must not be required for progression.
+- Optional controls needed for accessibility or comfort, such as mute, replay audio, or exit, may appear once play begins as secondary actions.
+- Any onboarding copy should stay short enough to support the launch goal instead of becoming a separate reading task.
+
+## Review Boundary
+
+- Review should confirm that the first interaction remains reachable in one action.
+- Review should confirm that no setup is required before the learner sees the first item.
+- Review should reject launch flows that add branching menus or extra confirmations before core play starts.

--- a/scripts/check-first-launch-flow.sh
+++ b/scripts/check-first-launch-flow.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+doc="$script_dir/../docs/first-launch-flow.md"
+readme="$script_dir/../README.md"
+
+[ -f "$doc" ] || {
+  printf 'missing required file: %s\n' "$doc" >&2
+  exit 1
+}
+
+[ -f "$readme" ] || {
+  printf 'missing required file: %s\n' "$readme" >&2
+  exit 1
+}
+
+check_doc() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$doc"; then
+    printf 'missing required first-launch flow content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_readme() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$readme"; then
+    printf 'missing README first-launch flow pointer: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_doc "First-Launch Flow"
+check_doc "Launch Goal"
+check_doc "Entry Sequence"
+check_doc "Transition to the First Item"
+check_doc "one action"
+check_doc "no setup"
+check_doc "single primary action"
+check_doc "directly into gameplay"
+check_doc "first item"
+check_doc "settings"
+check_doc "mute"
+check_doc "exit"
+check_readme "docs/first-launch-flow.md"
+
+printf 'First-launch flow check passed\n'


### PR DESCRIPTION
## Summary
- add a focused validation script for the first-launch flow contract
- define the minimal launch-to-first-item flow in a new planning doc
- link the new contract from the README

## Testing
- sh scripts/check-first-launch-flow.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced "First-Launch Flow" specification defining requirements for minimal app launch-to-gameplay transition with single primary user action, eliminating setup barriers, account creation, and intermediate menus.
  * Updated repository documentation index with reference to first-launch flow specification, entry sequence constraints, and stage transition rules.

* **Chores**
  * Added validation tool for first-launch flow documentation compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->