### PR TITLE
Define learn mode reinforcement moment

### DIFF
--- a/.codex-supervisor/issues/57/issue-journal.md
+++ b/.codex-supervisor/issues/57/issue-journal.md
@@ -1,0 +1,34 @@
+# Issue #57: Epic 7.4 - Define reinforcement moment
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/FNE/issues/57
+- Branch: codex/issue-57
+- Workspace: .
+- Journal: .codex-supervisor/issues/57/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 174f0b8f5fa730cb534d0d7619748a5820402aa5
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-10T23:10:45.409Z
+
+## Latest Codex Summary
+- Tightened the Learn Mode validation script to require reinforcement-specific language, reproduced the gap, and updated `docs/learn-mode.md` to define a short success-side reinforcement moment with replayed image/audio and minimal confirmation.
+
+## Active Failure Context
+- Reproduced before fix with `bash scripts/check-learn-mode.sh` after tightening the script.
+- Failure output: `missing required Learn Mode content: repeats the same image and pronunciation once more`
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: `docs/learn-mode.md` had generic success feedback but no explicit reinforcement moment covering replayed cue, minimal confirmation, and short duration.
+- What changed: Added issue-specific assertions to `scripts/check-learn-mode.sh`, reproduced the missing-content failure, and updated `docs/learn-mode.md` to define the short reinforcement moment in learner flow, timing cues, and learner feedback.
+- Current blocker: none
+- Next exact step: commit the focused doc-and-check update, then report the checkpoint with the passing focused verification.
+- Verification gap: broader cross-doc consistency checks were not run because the issue guidance prioritized the narrowest reproducible validation first.
+- Files touched: `docs/learn-mode.md`, `scripts/check-learn-mode.sh`, `.codex-supervisor/issues/57/issue-journal.md`
+- Rollback concern: low; changes are limited to spec text and its focused validation script.
+- Last focused command: `bash scripts/check-learn-mode.sh`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/docs/learn-mode.md
+++ b/docs/learn-mode.md
@@ -21,8 +21,9 @@ Define the first-exposure learner flow for Learn Mode so implementation can sequ
 5. The English term appears only after the learner has had a short first look at the image and heard the pronunciation once.
 6. The learner is prompted to respond on a simple confirmation beat or tap after the guided reveal.
 7. The mode judges the response with a forgiving timing rule and then gives immediate feedback.
-8. If the learner misses the response, the same item repeats with the same reveal order and an extra supportive cue before advancing.
-9. After the learner completes the required response for the item, the stage advances to the next item or to the end-of-stage summary.
+8. A successful response triggers a short reinforcement moment that repeats the same image and pronunciation once more with minimal confirmation before the mode advances.
+9. If the learner misses the response, the same item repeats with the same reveal order and an extra supportive cue before advancing.
+10. After the learner completes the required response for the item, the stage advances to the next item or to the end-of-stage summary.
 
 ## Presentation Timeline
 
@@ -39,11 +40,13 @@ Define the first-exposure learner flow for Learn Mode so implementation can sequ
 - The gap between image reveal and pronunciation should be short enough that both cues read as one teaching moment.
 - The gap before the response prompt should give the learner time to hear the word once and orient to the image before acting.
 - Feedback should arrive immediately after the learner response so the cause-and-effect stays obvious.
+- The success-side reinforcement moment should stay under 5 seconds so it feels like a clear replay of the learning cue, not a separate recap screen.
 - A repeated item should reuse the same cue order with slightly stronger support, such as replaying the pronunciation or visually emphasizing the image, instead of introducing a new rule.
 
 ## Learner Feedback
 
 - A successful response should confirm that the learner matched the cue correctly, with positive audiovisual feedback and no extra explanation wall.
+- That successful response should be followed by a short reinforcement moment that repeats the same image and pronunciation once more, paired with minimal confirmation instead of long text.
 - A missed or late response should signal that the learner can try again without framing the first exposure as failure.
 - Feedback should support first exposure by reinforcing the same item cues rather than hiding them.
 - Learn Mode should avoid harsh fail states, score penalties, or progress loss on the first miss for a new item.

--- a/scripts/check-learn-mode.sh
+++ b/scripts/check-learn-mode.sh
@@ -33,6 +33,9 @@ check_doc "image, then pronunciation, then text, then response prompt"
 check_doc "forgiving enough for beginners"
 check_doc "miss does not fail the item permanently"
 check_doc "every scheduled item has been passed at least once"
+check_doc "repeats the same image and pronunciation once more"
+check_doc "minimal confirmation"
+check_doc "under 5 seconds"
 check_readme "docs/learn-mode.md"
 
 printf 'Learn Mode check passed\n'


### PR DESCRIPTION
## Summary
- define the Learn Mode success-side reinforcement moment explicitly
- require replayed image and pronunciation, minimal confirmation, and a duration under 5 seconds
- tighten the Learn Mode doc check so the requirement is enforced

## Verification
- bash scripts/check-learn-mode.sh
- bash scripts/check-first-launch-flow.sh
- bash scripts/check-ux-rules.sh
- bash scripts/check-accessibility-baseline.sh

Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Learn Mode now triggers a reinforcement moment after correct responses, replaying the same image and pronunciation with minimal confirmation before advancing.

* **Documentation**
  * Updated Learn Mode documentation to describe the reinforcement moment step and establish a 5-second completion window.

* **Tests**
  * Enhanced validation script to verify reinforcement moment specifications in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->