### PR TITLE
Define AI content generation contract

### DIFF
--- a/.codex-supervisor/issues/74/issue-journal.md
+++ b/.codex-supervisor/issues/74/issue-journal.md
@@ -1,0 +1,35 @@
+# Issue #74: Epic 9.1 - Define AI content generation contract
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/FNE/issues/74
+- Branch: codex/issue-74
+- Workspace: .
+- Journal: .codex-supervisor/issues/74/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 3794e966c303c3b6a6c67e293eab2fe77eb3436e
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-12T03:35:43.932Z
+
+## Latest Codex Summary
+- Added a focused guard for the AI content generation contract, reproduced the failure as a missing contract doc, then defined the contract in docs and verified it against the canonical vocabulary item schema.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: This issue fits the repo's existing docs-plus-shell-check pattern, and the AI contract should be a single-item JSON contract aligned directly to the canonical vocabulary item schema.
+- What changed: Added `scripts/check-ai-content-generation-contract.sh`, reproduced the failure while `docs/ai-content-generation-contract.md` was missing, then added the contract doc and linked it from `README.md`.
+- Current blocker: none
+- Next exact step: Commit the focused contract and check changes on `codex/issue-74`.
+- Verification gap: Focused checks passed; broader repo-wide script sweep was not run because the issue guidance prioritized the narrowest reproducer and verification.
+- Files touched: `README.md`, `docs/ai-content-generation-contract.md`, `scripts/check-ai-content-generation-contract.sh`
+- Rollback concern: low; the change is additive and follows the established documentation-check pattern.
+- Last focused command: `sh scripts/check-ai-content-generation-contract.sh`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- Reproduced failure before implementation: missing `docs/ai-content-generation-contract.md` caused the new focused check to fail.
+- Focused verification run: `sh scripts/check-ai-content-generation-contract.sh` and `sh scripts/check-vocabulary-item-schema.sh`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The parent observation planning spec lives in [docs/parent-observation.md](docs/
 The shared visual readability and input simplicity rules live in [docs/ux-rules.md](docs/ux-rules.md).
 The practical accessibility baseline lives in [docs/accessibility-baseline.md](docs/accessibility-baseline.md).
 The minimal launch-to-play contract lives in [docs/first-launch-flow.md](docs/first-launch-flow.md).
+The AI content generation contract lives in [docs/ai-content-generation-contract.md](docs/ai-content-generation-contract.md).
 The canonical vocabulary item schema lives in [docs/vocabulary-item-schema.md](docs/vocabulary-item-schema.md).
 The pack schema lives in [docs/pack-schema.md](docs/pack-schema.md).
 The stage schema lives in [docs/stage-schema.md](docs/stage-schema.md).

--- a/docs/ai-content-generation-contract.md
+++ b/docs/ai-content-generation-contract.md
@@ -1,0 +1,69 @@
+# AI Content Generation Contract
+
+## Status
+Proposed
+
+## Purpose
+Define the structured JSON output contract for AI-authored vocabulary content so generated data can be reviewed and validated against the canonical vocabulary item schema without extra interpretation.
+
+Use `vocabulary item` as the content term for this contract. Do not replace it with `word card`, `flashcard`, or `entry`.
+
+## Output Contract
+
+The AI output must satisfy docs/vocabulary-item-schema.md exactly.
+
+The generator should return one JSON object for one vocabulary item at a time.
+
+```json
+{
+  "id": "apple",
+  "term": "apple",
+  "meaning": "りんご",
+  "pronunciation": "AP-uhl",
+  "imageAssetId": "img-apple",
+  "audioAssetId": "aud-apple",
+  "exampleSentence": "I eat an apple.",
+  "partOfSpeech": "noun",
+  "tags": ["fruit", "food"],
+  "notes": "Common beginner vocabulary."
+}
+```
+
+Do not wrap the JSON object in markdown fences.
+
+Do not prepend or append explanations, labels, or commentary outside the JSON object.
+
+## Required Output Fields
+
+- `id`: Stable item identifier string.
+- `term`: The vocabulary item shown to the learner.
+- `meaning`: The short meaning or translation used to describe the item.
+- `pronunciation`: A learner-facing pronunciation hint, such as a simple phonetic guide or IPA-like string.
+- `imageAssetId`: Opaque reference to the image asset for the item.
+- `audioAssetId`: Opaque reference to the pronunciation audio asset for the item.
+
+## Optional Output Fields
+
+- `exampleSentence`: A short example sentence for later study or review screens.
+- `partOfSpeech`: A compact grammatical label such as `noun` or `verb`.
+- `tags`: An array of descriptive strings used for grouping or filtering.
+- `notes`: Additional editorial notes that do not change the learning content.
+
+## Validation Rules
+
+- Reject the output if any required field is missing.
+- Reject the output if any required field is present but not a string.
+- Reject the output if any required string field is blank or contains only whitespace.
+- Reject the output if `tags` is present but is not an array of non-empty strings.
+- Reject the output if `exampleSentence`, `partOfSpeech`, or `notes` are present but are not strings.
+- Unknown fields must be rejected.
+- Reject arrays of items, wrapper objects, or mixed response formats because this contract is for one vocabulary item only.
+- Treat `imageAssetId` and `audioAssetId` as opaque identifiers at this layer; asset existence is validated separately.
+
+## Prompting Guidance
+
+- Ask for exactly one vocabulary item JSON object per response.
+- Name the required fields explicitly in the prompt so the model does not omit them.
+- Reuse the canonical field names from `docs/vocabulary-item-schema.md` instead of aliases or translated keys.
+- Keep the contract data-only so downstream validation can stay deterministic and separate from gameplay logic.
+- If a later workflow needs batch generation, define that as a separate wrapper contract instead of changing the single-item contract here.

--- a/scripts/check-ai-content-generation-contract.sh
+++ b/scripts/check-ai-content-generation-contract.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+doc="$script_dir/../docs/ai-content-generation-contract.md"
+readme="$script_dir/../README.md"
+
+check_doc() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$doc"; then
+    printf 'missing required AI content contract content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_readme() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$readme"; then
+    printf 'missing README AI content contract pointer: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_doc "AI Content Generation Contract"
+check_doc "Output Contract"
+check_doc "Required Output Fields"
+check_doc "Optional Output Fields"
+check_doc "Validation Rules"
+check_doc "Prompting Guidance"
+check_doc "The AI output must satisfy docs/vocabulary-item-schema.md exactly."
+check_doc "Unknown fields must be rejected."
+check_doc "Do not wrap the JSON object in markdown fences."
+check_doc '- `id`:'
+check_doc '- `term`:'
+check_doc '- `meaning`:'
+check_doc '- `pronunciation`:'
+check_doc '- `imageAssetId`:'
+check_doc '- `audioAssetId`:'
+check_readme "docs/ai-content-generation-contract.md"
+
+printf 'AI content generation contract check passed\n'


### PR DESCRIPTION
## Summary
- add the AI content generation contract document aligned to the canonical vocabulary item schema
- add a focused shell check for the contract and README pointer
- document single-item JSON-only output requirements and explicit required fields

## Testing
- sh scripts/check-ai-content-generation-contract.sh
- sh scripts/check-vocabulary-item-schema.sh

Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added AI Content Generation Contract defining vocabulary-item output specifications with required fields (ID, term, meaning, pronunciation, image/audio assets) and optional fields (example sentence, part of speech, tags, notes)
  * Updated repository documentation index to reference the new contract specification

* **Chores**
  * Added validation script to verify documentation consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->