### PR TITLE
Epic 11.2 - Define repetition limits (#103)

### DIFF
--- a/.codex-supervisor/issues/103/issue-journal.md
+++ b/.codex-supervisor/issues/103/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #103: Epic 11.2 - Define repetition limits
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/FNE/issues/103
+- Branch: codex/issue-103
+- Workspace: .
+- Journal: .codex-supervisor/issues/103/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 1753259d21aceeff157405b11608c2d2d74b266b
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-18T10:01:19.366Z
+
+## Latest Codex Summary
+- Reproduced the gap at the review-loop contract boundary by tightening `scripts/check-review-loop.sh` to require explicit numeric repetition-limit language. Updated `docs/review-loop.md` to define a maximum of two review resurfacing passes per weak word in the same stage after first-pass exposure, with unresolved items forced to summary or future follow-up instead of a third pass. Focused review-loop and weak-word checks now pass.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: `docs/review-loop.md` only promised a finite loop in prose and left the actual repetition cap implicit, so issue #103 should be fixed by tightening the contract and its guard script rather than broad repo changes.
+- What changed: Added explicit review-loop guard assertions in `scripts/check-review-loop.sh`; updated `docs/review-loop.md` so the baseline loop allows at most two review resurfacing passes per weak word after first-pass exposure and forbids a third resurfacing pass in the same stage.
+- Current blocker: none
+- Next exact step: Commit the focused spec+guard checkpoint on `codex/issue-103` and leave the branch ready for PR/open-review flow.
+- Verification gap: Did not run broader repo-wide doc checks beyond the review-loop and weak-word guards because this issue was scoped to the review-loop contract.
+- Files touched: scripts/check-review-loop.sh; docs/review-loop.md; .codex-supervisor/issues/103/issue-journal.md
+- Rollback concern: Low; the change narrows an existing ambiguous contract into explicit limits without changing unrelated mode rules.
+- Last focused command: sh scripts/check-review-loop.sh && sh scripts/check-weak-word-scoring-rules.sh
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/docs/review-loop.md
+++ b/docs/review-loop.md
@@ -21,9 +21,11 @@ Define how incorrect, unresolved, or weak items come back for practice so implem
 
 - The review loop should queue weak words only after the stage has offered each scheduled item one first-pass exposure in its planned order.
 - The first review pass should requeue each weak word once in the order the learner originally weakened it, so the learner sees a short and understandable recovery sequence instead of a reshuffled backlog.
+- The baseline review loop allows at most two review resurfacing passes in the same stage after the first-pass exposure cycle is complete.
 - If a resurfaced weak word is cleared cleanly on its review pass, it leaves the current-stage review queue.
-- If a resurfaced weak word still resolves with support, retry reduction, or unresolved status, it may remain in the queue for one more short recovery pass, but the loop should stay finite and should not trap the learner in endless retries.
-- When the stage reaches its defined short review limit and some weak words are still unresolved, the stage should mark them for summary or future follow-up rather than silently dropping them.
+- A weak word can appear no more than twice in the review loop after its first-pass exposure, which means the learner sees at most the first review resurfacing and one final short recovery resurfacing for that item in the same stage.
+- If a resurfaced weak word still resolves with support, retry reduction, or unresolved status after its second review resurfacing, it must move to summary or future follow-up instead of entering a third review resurfacing pass.
+- When the stage reaches this explicit short review limit and some weak words are still unresolved, the stage should mark them for summary or future follow-up rather than silently dropping them.
 
 ## Review Session Behavior
 

--- a/scripts/check-review-loop.sh
+++ b/scripts/check-review-loop.sh
@@ -45,6 +45,9 @@ check_doc "queue weak words only after the stage has offered each scheduled item
 check_doc "fresh prompt under that mode's normal rules"
 check_doc "closes the first learning cycle cleanly"
 check_doc "future spaced repetition layers should extend this same weak-word state"
+check_doc "at most two review resurfacing passes in the same stage"
+check_doc "can appear no more than twice in the review loop after its first-pass exposure"
+check_doc "must move to summary or future follow-up instead of entering a third review resurfacing pass"
 check_readme "docs/review-loop.md"
 
 printf 'Review loop check passed\n'


### PR DESCRIPTION
Closes #103
This PR was opened by codex-supervisor.
Latest Codex summary:

Committed `c733c9f` on `codex/issue-103` with the narrowest fix for the reproduced gap. The review-loop contract now states explicit finite limits: after first-pass exposure, a weak word can resurface at most twice in the same stage, and unresolved items must exit to summary or future follow-up instead of entering a third resurfacing pass. I tightened the focused guard first, reproduced the failure there, then updated the spec and reran the adjacent weak-word contract check.

Summary: Added an explicit two-pass review resurfacing cap to `docs/review-loop.md`, tightened `scripts/check-review-loop.sh` to require that wording, updated the issue journal, and committed the checkpoint as `c733c9f`.
State hint: draft_pr
Blocked reason: none
Tests: `sh scripts/check-review-loop.sh`; `sh scripts/check-weak-word-scoring-rules.sh`
Failure signature: none
Next action: Open or update a draft PR for commit `c733c9f` and continue local review only if broader doc-contract checks are required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established explicit limits on review-loop resurfacing with maximum of two passes per stage and clear escalation paths for unresolved issues

* **Tests**
  * Added validation checks to enforce the new review-loop resurfacing constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->