### PR TITLE
Epic 11.3 - Define review prioritization (#104)

### DIFF
--- a/.codex-supervisor/issues/104/issue-journal.md
+++ b/.codex-supervisor/issues/104/issue-journal.md
@@ -1,0 +1,35 @@
+# Issue #104: Epic 11.3 - Define review prioritization
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/FNE/issues/104
+- Branch: codex/issue-104
+- Workspace: .
+- Journal: .codex-supervisor/issues/104/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: a611459c6cd5e60c40e5d9b35b1b887454d5b9ef
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-18T10:08:19.938Z
+
+## Latest Codex Summary
+- Added a focused `check-review-loop.sh` reproducer for missing review prioritization/fairness rules, then updated `docs/review-loop.md` so ordering is anchored to weak-word event order and second resurfacing cannot starve first resurfacing coverage for other weak words.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: `docs/review-loop.md` defined weak-word entry and repetition caps but did not explicitly define mixed-item prioritization, so supported-repeat clusters could implicitly over-focus the queue and starve later unresolved items.
+- What changed: Tightened `scripts/check-review-loop.sh` with explicit prioritization/fairness assertions, reproduced the missing rule, then added review-loop wording that keeps one authoritative queue ordered by first-pass weak-word events and requires every weak word to get a first resurfacing before any item gets a second resurfacing when capacity is tight.
+- Current blocker: none
+- Next exact step: Review the wording for issue acceptance, then open or update a draft PR if this checkpoint should be sent upstream before more review-loop work lands.
+- Verification gap: No broader repo-wide doc sweep beyond the directly related weak-word and KPI checks.
+- Files touched: docs/review-loop.md; scripts/check-review-loop.sh; .codex-supervisor/issues/104/issue-journal.md
+- Rollback concern: Low; this is a spec/check alignment change localized to review-loop documentation and its focused verifier.
+- Last focused command: ./scripts/check-review-loop.sh
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- Reproduced failure before spec edit: `missing required review loop content: prioritize weak words by the order their first-pass outcomes marked them weak`
+- Verified after edit: `./scripts/check-review-loop.sh && ./scripts/check-weak-word-scoring-rules.sh && ./scripts/check-learning-kpis.sh`

--- a/docs/review-loop.md
+++ b/docs/review-loop.md
@@ -21,9 +21,13 @@ Define how incorrect, unresolved, or weak items come back for practice so implem
 
 - The review loop should queue weak words only after the stage has offered each scheduled item one first-pass exposure in its planned order.
 - The first review pass should requeue each weak word once in the order the learner originally weakened it, so the learner sees a short and understandable recovery sequence instead of a reshuffled backlog.
+- The review planner should prioritize weak words by the order their first-pass outcomes marked them weak, regardless of whether the item entered from a supported repeat, retry-reduced clear, or unresolved result.
+- The rule is that supported-repeat and unresolved items share the same review queue, because review priority should come from the authoritative weak-word event order, not from a derived severity tier that overweights one failure pattern.
 - The baseline review loop allows at most two review resurfacing passes in the same stage after the first-pass exposure cycle is complete.
 - If a resurfaced weak word is cleared cleanly on its review pass, it leaves the current-stage review queue.
 - A weak word can appear no more than twice in the review loop after its first-pass exposure, which means the learner sees at most the first review resurfacing and one final short recovery resurfacing for that item in the same stage.
+- The review planner must not let one failure pattern monopolize the limited review slots; a cluster of early supported repeats cannot keep later unresolved weak words from receiving their own first resurfacing.
+- The review planner should ensure that when review capacity runs short, every queued weak word should receive its first resurfacing before any item claims a second review resurfacing, so the repetition limit stays fair across the whole weak-word set.
 - If a resurfaced weak word still resolves with support, retry reduction, or unresolved status after its second review resurfacing, it must move to summary or future follow-up instead of entering a third review resurfacing pass.
 - When the stage reaches this explicit short review limit and some weak words are still unresolved, the stage should mark them for summary or future follow-up rather than silently dropping them.
 

--- a/scripts/check-review-loop.sh
+++ b/scripts/check-review-loop.sh
@@ -48,6 +48,10 @@ check_doc "future spaced repetition layers should extend this same weak-word sta
 check_doc "at most two review resurfacing passes in the same stage"
 check_doc "can appear no more than twice in the review loop after its first-pass exposure"
 check_doc "must move to summary or future follow-up instead of entering a third review resurfacing pass"
+check_doc "prioritize weak words by the order their first-pass outcomes marked them weak"
+check_doc "supported-repeat and unresolved items share the same review queue"
+check_doc "must not let one failure pattern monopolize the limited review slots"
+check_doc "when review capacity runs short, every queued weak word should receive its first resurfacing before any item claims a second review resurfacing"
 check_readme "docs/review-loop.md"
 
 printf 'Review loop check passed\n'


### PR DESCRIPTION
Closes #104
This PR was opened by codex-supervisor.
Latest Codex summary:

Defined the missing review prioritization rules in [docs/review-loop.md](/Users/tomoakikawada/Dev/FNE/FNE-codex-supervisor/.local/worktrees/issue-104/docs/review-loop.md) and tightened [scripts/check-review-loop.sh](/Users/tomoakikawada/Dev/FNE/FNE-codex-supervisor/.local/worktrees/issue-104/scripts/check-review-loop.sh) to reproduce that gap first. The spec now makes the ordering explicit: review priority follows the authoritative first-pass weak-word event order, supported-repeat and unresolved items stay in one queue, one failure pattern cannot monopolize limited review slots, and every weak word gets a first resurfacing before any item gets a second resurfacing when capacity is tight.

I reproduced the failure with the focused check, fixed the spec, reran the narrow verification plus adjacent weak-word/KPI checks, updated the issue journal, and committed the checkpoint as `be3aa46` (`Define review prioritization rules`). The worktree still has untracked supervisor runtime artifacts under `.codex-supervisor/pre-merge/`, `.codex-supervisor/replay/`, and `.codex-supervisor/turn-in-progress.json`, which I left untouched.

Summary: Added explicit review prioritization and fairness rules to the review-loop spec, backed by a focused reproducing check and committed as `be3aa46`
State hint: draft_pr
Blocked reason: none
Tests: `./scripts/check-review-loop.sh`; `./scripts/check-weak-word-scoring-rules.sh`; `./scripts/check-learning-kpis.sh`
Failure signature: none
Next action: O...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated review prioritization specification to enforce chronological ordering of weak words and fairness constraints, ensuring limited review slots are allocated equitably across all weak words, with first resurfacing preceding second resurfacing when capacity is constrained.

* **Chores**
  * Added validation checks for new documentation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->