### PR TITLE
Define review-loop transition to future systems

### DIFF
--- a/.codex-supervisor/issues/105/issue-journal.md
+++ b/.codex-supervisor/issues/105/issue-journal.md
@@ -1,0 +1,35 @@
+# Issue #105: Epic 11.4 - Define transition to future systems
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/FNE/issues/105
+- Branch: codex/issue-105
+- Workspace: .
+- Journal: .codex-supervisor/issues/105/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 0bf5137871664bfeb98660f4abe98c0395d24594
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-18T10:20:55.027Z
+
+## Latest Codex Summary
+- Added a focused `check-review-loop-transition.sh` reproducer for the missing transition note, captured the missing-doc failure, then added `docs/review-loop-transition.md` and a README pointer that keep future persistence and spaced-repetition plans anchored to the existing review-loop and measurement boundaries.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The repo already defined the in-stage review-loop contract and its measurement boundary, but issue #105 had no focused transition note or guard for how later persistence and spaced-repetition systems must extend that contract without widening v1.
+- What changed: Added `scripts/check-review-loop-transition.sh`; reproduced the gap as a missing `docs/review-loop-transition.md`; added that transition note plus a README pointer. The new note keeps future persistence tied to authoritative weak-word outcomes and keeps future spaced repetition as a later cross-session layer rather than a rewrite of the current-stage loop.
+- Current blocker: none
+- Next exact step: Commit the focused docs-and-checkpoint update on `codex/issue-105`, then open or update a draft PR if supervisor flow requires an early review checkpoint.
+- Verification gap: Verification is limited to focused doc guards; there is no runtime implementation for persistence or scheduler behavior in this repo yet.
+- Files touched: .codex-supervisor/issues/105/issue-journal.md, README.md, docs/review-loop-transition.md, scripts/check-review-loop-transition.sh
+- Rollback concern: Low; this is a documentation boundary plus focused verifier, with no runtime behavior changes.
+- Last focused command: sh scripts/check-review-loop-transition.sh && sh scripts/check-review-loop.sh && sh scripts/check-measurement-points.sh
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- Reproduced failure before doc edit: `missing required file: .../docs/review-loop-transition.md`
+- Verified after edit: `Review loop transition check passed`

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The PoC evaluation bar for first external playtests lives in [docs/poc-evaluatio
 The Learn Mode behavior spec lives in [docs/learn-mode.md](docs/learn-mode.md).
 The learning KPI definitions for recognition and repetition signals live in [docs/learning-kpis.md](docs/learning-kpis.md).
 The review and weak-word loop spec lives in [docs/review-loop.md](docs/review-loop.md).
+The transition note from the v1 review loop to future persistence and spaced-repetition systems lives in [docs/review-loop-transition.md](docs/review-loop-transition.md).
 The Battle Mode behavior spec lives in [docs/battle-mode.md](docs/battle-mode.md).
 The Listen & Match Mode behavior spec lives in [docs/listen-and-match-mode.md](docs/listen-and-match-mode.md).
 The parent observation planning spec lives in [docs/parent-observation.md](docs/parent-observation.md).

--- a/docs/review-loop-transition.md
+++ b/docs/review-loop-transition.md
@@ -1,0 +1,42 @@
+# Review Loop Transition to Future Systems
+
+## Status
+Proposed
+
+## Purpose
+Define how the v1 short review loop can hand off to later persistence and spaced-repetition systems without rewriting the current-stage recovery contract in [docs/review-loop.md](review-loop.md) or the measurement boundary in [docs/measurement-points.md](measurement-points.md).
+
+## Current V1 Boundary
+
+- V1 owns only the short in-stage review loop that happens after the learner has received one first-pass exposure to each scheduled item.
+- V1 keeps weak-word handling inside the current stage run, including short resurfacing, final unresolved visibility, and summary or future follow-up when the review limit is reached.
+- V1 must not require persistent learner identity, server-owned history, or cross-device syncing to decide whether an item is weak, resurfaced, resolved, or still active.
+- V1 must not reopen or rewrite first-pass mode rules in Learn Mode, Listen & Match Mode, or Battle Mode, because those modes already provide the authoritative outcome labels that the review loop consumes.
+
+## Persistence Compatibility
+
+- A later persistence layer should persist the same weak-word outcomes that v1 already produces instead of replacing them with a second incompatible status model.
+- The persisted record should start from authoritative gameplay outcome records such as weak-word-enqueued, weak-word-resolved, and weak-word-still-active boundaries already described in [docs/measurement-points.md](measurement-points.md).
+- A future save path may store unresolved or partially recovered weak words after the stage reaches summary or future follow-up, but it should not change what counted as a weak word during the original stage.
+- The first durable version should remain compatible with a single-session browser run by treating persistence as an optional extension of the same run results, not as a prerequisite for stage completion.
+- If later work adds local storage, backend storage, or export/import paths, those paths should preserve the same item order, outcome meaning, and review-limit result that v1 already documents.
+
+## Future Spaced Repetition Compatibility
+
+- A future cross-session scheduler should extend the same weak-word state instead of inventing a parallel retry taxonomy.
+- The scheduler may decide when an unresolved or recently supported item returns in a later session, but it should treat the v1 loop as the first recovery layer, not as a disposable prototype.
+- Cross-session spacing can add interval choice, decay rules, or resurfacing priority across visits, but it should not erase whether the item was a clean first-pass clear, a supported clear, or still unresolved at the end of the stage.
+- Later spaced repetition should begin only after the current stage has finished its documented short review closure, so future scheduling does not compete with the in-stage loop for the same recovery job.
+
+## Measurement and Handoff Compatibility
+
+- Later persistence and spacing work should anchor to the authoritative gameplay outcome records already identified in [docs/measurement-points.md](measurement-points.md), not to parent-facing summaries, convenience counters, or UI badges.
+- The handoff from v1 review to later systems should occur at the point where the stage reaches summary or future follow-up with its final weak-word state already decided.
+- Any later rollup should preserve the distinction between stage-sized outcomes and cross-session history so parent observation and learner-facing summaries do not silently redefine the underlying result.
+- If a later system reads multiple stored records to assemble future review candidates, it should use one committed snapshot of the authoritative run results instead of mixing partial writes from different moments.
+
+## Review Boundary
+
+- Review should confirm that this note keeps the v1 contract stage-sized, session-sized, and compatible with a single-session browser run.
+- Review should confirm that later persistence and spaced repetition are described as extensions of the current weak-word outcomes rather than replacements for the existing loop.
+- Review should reject proposals that require identity, backend storage, or scheduler state before the learner can complete the current-stage review loop.

--- a/scripts/check-review-loop-transition.sh
+++ b/scripts/check-review-loop-transition.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+doc="$script_dir/../docs/review-loop-transition.md"
+readme="$script_dir/../README.md"
+
+[ -f "$doc" ] || {
+  printf 'missing required file: %s\n' "$doc" >&2
+  exit 1
+}
+
+[ -f "$readme" ] || {
+  printf 'missing required file: %s\n' "$readme" >&2
+  exit 1
+}
+
+check_doc() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$doc"; then
+    printf 'missing required review loop transition content: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_readme() {
+  pattern="$1"
+  if ! grep -Fq -- "$pattern" "$readme"; then
+    printf 'missing README review loop transition pointer: %s\n' "$pattern" >&2
+    exit 1
+  fi
+}
+
+check_doc "Review Loop Transition to Future Systems"
+check_doc "Current V1 Boundary"
+check_doc "Persistence Compatibility"
+check_doc "Future Spaced Repetition Compatibility"
+check_doc "Measurement and Handoff Compatibility"
+check_doc "Review Boundary"
+check_doc "short in-stage review loop"
+check_doc "must not require persistent learner identity"
+check_doc "should persist the same weak-word outcomes"
+check_doc "same weak-word state"
+check_doc "must not reopen or rewrite first-pass mode rules"
+check_doc "authoritative gameplay outcome records"
+check_doc "single-session browser run"
+check_doc "cross-session scheduler"
+check_doc "summary or future follow-up"
+check_readme "docs/review-loop-transition.md"
+
+printf 'Review loop transition check passed\n'

--- a/scripts/check-review-loop-transition.sh
+++ b/scripts/check-review-loop-transition.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 doc="$script_dir/../docs/review-loop-transition.md"
 readme="$script_dir/../README.md"
 


### PR DESCRIPTION
## Summary
- add a focused review-loop transition guard for issue #105
- define the v1-to-future-systems transition note for persistence and spaced repetition
- keep the transition anchored to the existing review-loop and measurement boundaries

## Testing
- sh scripts/check-review-loop-transition.sh
- sh scripts/check-review-loop.sh
- sh scripts/check-measurement-points.sh

Closes #105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive transition docs describing how the v1 review loop hands off to future persistence and spaced‑repetition systems, compatibility requirements, handoff/measurement anchors, and a checklist.
  * Added a repository README pointer to the new transition documentation.
  * Created an issue journal entry recording the investigation, notes, and verification result.

* **Chores**
  * Added an executable validation script that checks required documentation content and reports pass/fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->