### PR TITLE
Epic 12.3 - Implement first audio-backed reveal and keyboard input judgment (#115)

### DIFF
--- a/.codex-supervisor/issues/115/issue-journal.md
+++ b/.codex-supervisor/issues/115/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #115: Epic 12.3 - Implement first audio-backed reveal and keyboard input judgment
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/FNE/issues/115
+- Branch: codex/issue-115
+- Workspace: .
+- Journal: .codex-supervisor/issues/115/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: c8b90b9219ea12b064a8f5da0ecd3343afcc5a8f
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-18T14:17:38.505Z
+
+## Latest Codex Summary
+- Added a focused reveal-round state test, implemented a Phaser scene that shows the demo image cue, starts pronunciation on `Enter`, judges the typed first letter, and exposes visible success/failure plus replay without reload. Local `test`, `typecheck`, and `lint` now pass.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The issue was still in placeholder-scene state; the narrowest safe path was a small round-state boundary for start, judgment, and replay, then wiring BootScene to that boundary.
+- What changed: Added `packages/runtime/src/reveal-round.ts` plus `apps/web/src/revealRound.test.ts`; updated `BootScene` to preload the demo image/audio, show the image cue, start the cue on `Enter`, judge the first typed letter, reveal visible success/failure feedback, and allow replay with `Enter`; exported the new runtime subpath in `packages/runtime/package.json`.
+- Current blocker: none
+- Next exact step: Commit the checkpoint on `codex/issue-115`, then open or update the draft PR if the supervisor asks for it.
+- Verification gap: Browser automation confirmed ready, failure, restart, and success visuals with keyboard-only input, but actual audible playback still needs a human ear confirmation in a local browser session.
+- Files touched: .codex-supervisor/issues/115/issue-journal.md, apps/web/src/revealRound.test.ts, packages/runtime/package.json, packages/runtime/src/reveal-round.ts, packages/runtime/src/scenes/BootScene.ts
+- Rollback concern: The scene now depends on `Enter` to trigger the pronunciation cue so autoplay restrictions do not hide the start of the loop; if product direction changes toward immediate autoplay, revisit browser audio-unlock behavior before changing the start gate.
+- Last focused command: pnpm lint
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/apps/web/src/revealRound.test.ts
+++ b/apps/web/src/revealRound.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 
 describe("reveal round state", () => {
   it("gates audio start, judges the typed first letter, and resets for replay", () => {
-    const state = createRevealRoundState({
+    const setup = createRevealRoundState({
       id: "apple",
       term: "apple",
       meaning: "りんご",
@@ -17,15 +17,25 @@ describe("reveal round state", () => {
       audioAssetId: "aud-apple"
     });
 
+    expect(setup.ok).toBe(true);
+
+    if (!setup.ok) {
+      throw new Error("expected a playable reveal round");
+    }
+
+    const state = setup.state;
+
     expect(state.phase).toBe("ready");
     expect(state.expectedKey).toBe("a");
     expect(state.audioCueRequestCount).toBe(0);
+    expect(state.feedbackBody).toBe("Press Enter to hear the word, then type its first letter.");
 
     const started = startRevealRound(state);
 
     expect(started.phase).toBe("awaiting-answer");
     expect(started.audioCueRequestCount).toBe(1);
     expect(started.feedbackTitle).toBe("Type the first letter");
+    expect(started.feedbackBody).toBe("Listen for the word, then type its first letter.");
 
     const failed = judgeRevealRoundInput(started, "x");
 
@@ -43,5 +53,26 @@ describe("reveal round state", () => {
     expect(succeeded.phase).toBe("success");
     expect(succeeded.feedbackBody).toContain("apple");
     expect(succeeded.feedbackBody).toContain("A");
+  });
+
+  it("returns a recoverable content error when the term has no Latin letter", () => {
+    const setup = createRevealRoundState({
+      id: "ringo",
+      term: "りんご",
+      meaning: "apple",
+      pronunciation: "ringo",
+      imageAssetId: "img-ringo",
+      audioAssetId: "aud-ringo"
+    });
+
+    expect(setup.ok).toBe(false);
+
+    if (setup.ok) {
+      throw new Error("expected a content error");
+    }
+
+    expect(setup.error.kind).toBe("content-error");
+    expect(setup.error.itemId).toBe("ringo");
+    expect(setup.error.message).toContain('does not contain a Latin letter');
   });
 });

--- a/apps/web/src/revealRound.test.ts
+++ b/apps/web/src/revealRound.test.ts
@@ -1,0 +1,47 @@
+import {
+  createRevealRoundState,
+  judgeRevealRoundInput,
+  restartRevealRound,
+  startRevealRound
+} from "@fne/runtime/reveal-round";
+import { describe, expect, it } from "vitest";
+
+describe("reveal round state", () => {
+  it("gates audio start, judges the typed first letter, and resets for replay", () => {
+    const state = createRevealRoundState({
+      id: "apple",
+      term: "apple",
+      meaning: "りんご",
+      pronunciation: "AP-uhl",
+      imageAssetId: "img-apple",
+      audioAssetId: "aud-apple"
+    });
+
+    expect(state.phase).toBe("ready");
+    expect(state.expectedKey).toBe("a");
+    expect(state.audioCueRequestCount).toBe(0);
+
+    const started = startRevealRound(state);
+
+    expect(started.phase).toBe("awaiting-answer");
+    expect(started.audioCueRequestCount).toBe(1);
+    expect(started.feedbackTitle).toBe("Type the first letter");
+
+    const failed = judgeRevealRoundInput(started, "x");
+
+    expect(failed.phase).toBe("failure");
+    expect(failed.lastInput).toBe("x");
+    expect(failed.feedbackBody).toContain("A");
+    expect(failed.feedbackBody).toContain("X");
+
+    const replayReady = restartRevealRound(failed);
+    const replayStarted = startRevealRound(replayReady);
+    const succeeded = judgeRevealRoundInput(replayStarted, "A");
+
+    expect(replayReady.phase).toBe("ready");
+    expect(replayStarted.audioCueRequestCount).toBe(2);
+    expect(succeeded.phase).toBe("success");
+    expect(succeeded.feedbackBody).toContain("apple");
+    expect(succeeded.feedbackBody).toContain("A");
+  });
+});

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./demo-content": "./src/demo-content.ts"
+    "./demo-content": "./src/demo-content.ts",
+    "./reveal-round": "./src/reveal-round.ts"
   },
   "scripts": {
     "typecheck": "tsc --project tsconfig.json --noEmit"

--- a/packages/runtime/src/reveal-round.ts
+++ b/packages/runtime/src/reveal-round.ts
@@ -14,6 +14,22 @@ export interface RevealRoundState {
   lastInput: string | null;
 }
 
+export interface RevealRoundContentError {
+  kind: "content-error";
+  itemId: string;
+  message: string;
+}
+
+export type RevealRoundSetupResult =
+  | {
+      ok: true;
+      state: RevealRoundState;
+    }
+  | {
+      ok: false;
+      error: RevealRoundContentError;
+    };
+
 function normalizeKeyboardLetter(key: string): string | null {
   if (key.length !== 1) {
     return null;
@@ -24,7 +40,7 @@ function normalizeKeyboardLetter(key: string): string | null {
   return /^[a-z]$/.test(normalized) ? normalized : null;
 }
 
-function getExpectedKey(term: string): string {
+function getExpectedKey(term: string): string | null {
   for (const character of term) {
     const normalizedCharacter = normalizeKeyboardLetter(character);
 
@@ -33,22 +49,36 @@ function getExpectedKey(term: string): string {
     }
   }
 
-  throw new Error(`Vocabulary item term "${term}" must contain at least one latin letter.`);
+  return null;
 }
 
-export function createRevealRoundState(item: VocabularyItem): RevealRoundState {
+export function createRevealRoundState(item: VocabularyItem): RevealRoundSetupResult {
   const expectedKey = getExpectedKey(item.term);
 
+  if (expectedKey === null) {
+    return {
+      ok: false,
+      error: {
+        kind: "content-error",
+        itemId: item.id,
+        message: `Vocabulary item "${item.id}" cannot start the reveal round because term "${item.term}" does not contain a Latin letter for keyboard judgment.`
+      }
+    };
+  }
+
   return {
-    itemId: item.id,
-    termLabel: item.term,
-    meaningLabel: item.meaning,
-    expectedKey,
-    phase: "ready",
-    audioCueRequestCount: 0,
-    feedbackTitle: "Ready to listen?",
-    feedbackBody: `Press Enter to hear the word, then type ${expectedKey.toUpperCase()}.`,
-    lastInput: null
+    ok: true,
+    state: {
+      itemId: item.id,
+      termLabel: item.term,
+      meaningLabel: item.meaning,
+      expectedKey,
+      phase: "ready",
+      audioCueRequestCount: 0,
+      feedbackTitle: "Ready to listen?",
+      feedbackBody: "Press Enter to hear the word, then type its first letter.",
+      lastInput: null
+    }
   };
 }
 
@@ -62,7 +92,7 @@ export function startRevealRound(state: RevealRoundState): RevealRoundState {
     phase: "awaiting-answer",
     audioCueRequestCount: state.audioCueRequestCount + 1,
     feedbackTitle: "Type the first letter",
-    feedbackBody: `Listen for the word, then press ${state.expectedKey.toUpperCase()}.`,
+    feedbackBody: "Listen for the word, then type its first letter.",
     lastInput: null
   };
 }
@@ -105,7 +135,7 @@ export function restartRevealRound(state: RevealRoundState): RevealRoundState {
     ...state,
     phase: "ready",
     feedbackTitle: "Ready to listen?",
-    feedbackBody: `Press Enter to hear the word, then type ${state.expectedKey.toUpperCase()}.`,
+    feedbackBody: "Press Enter to hear the word, then type its first letter.",
     lastInput: null
   };
 }

--- a/packages/runtime/src/reveal-round.ts
+++ b/packages/runtime/src/reveal-round.ts
@@ -1,0 +1,111 @@
+import type { VocabularyItem } from "@fne/shared";
+
+export type RevealRoundPhase = "ready" | "awaiting-answer" | "success" | "failure";
+
+export interface RevealRoundState {
+  itemId: string;
+  termLabel: string;
+  meaningLabel: string;
+  expectedKey: string;
+  phase: RevealRoundPhase;
+  audioCueRequestCount: number;
+  feedbackTitle: string;
+  feedbackBody: string;
+  lastInput: string | null;
+}
+
+function normalizeKeyboardLetter(key: string): string | null {
+  if (key.length !== 1) {
+    return null;
+  }
+
+  const normalized = key.toLowerCase();
+
+  return /^[a-z]$/.test(normalized) ? normalized : null;
+}
+
+function getExpectedKey(term: string): string {
+  for (const character of term) {
+    const normalizedCharacter = normalizeKeyboardLetter(character);
+
+    if (normalizedCharacter !== null) {
+      return normalizedCharacter;
+    }
+  }
+
+  throw new Error(`Vocabulary item term "${term}" must contain at least one latin letter.`);
+}
+
+export function createRevealRoundState(item: VocabularyItem): RevealRoundState {
+  const expectedKey = getExpectedKey(item.term);
+
+  return {
+    itemId: item.id,
+    termLabel: item.term,
+    meaningLabel: item.meaning,
+    expectedKey,
+    phase: "ready",
+    audioCueRequestCount: 0,
+    feedbackTitle: "Ready to listen?",
+    feedbackBody: `Press Enter to hear the word, then type ${expectedKey.toUpperCase()}.`,
+    lastInput: null
+  };
+}
+
+export function startRevealRound(state: RevealRoundState): RevealRoundState {
+  if (state.phase === "awaiting-answer") {
+    return state;
+  }
+
+  return {
+    ...state,
+    phase: "awaiting-answer",
+    audioCueRequestCount: state.audioCueRequestCount + 1,
+    feedbackTitle: "Type the first letter",
+    feedbackBody: `Listen for the word, then press ${state.expectedKey.toUpperCase()}.`,
+    lastInput: null
+  };
+}
+
+export function judgeRevealRoundInput(
+  state: RevealRoundState,
+  key: string
+): RevealRoundState {
+  if (state.phase !== "awaiting-answer") {
+    return state;
+  }
+
+  const normalizedKey = normalizeKeyboardLetter(key);
+
+  if (normalizedKey === null) {
+    return state;
+  }
+
+  if (normalizedKey === state.expectedKey) {
+    return {
+      ...state,
+      phase: "success",
+      feedbackTitle: "Nice hit",
+      feedbackBody: `${state.termLabel} starts with ${state.expectedKey.toUpperCase()}. Press Enter to replay.`,
+      lastInput: normalizedKey
+    };
+  }
+
+  return {
+    ...state,
+    phase: "failure",
+    feedbackTitle: "Not yet",
+    feedbackBody: `${state.termLabel} starts with ${state.expectedKey.toUpperCase()}, not ${normalizedKey.toUpperCase()}. Press Enter to replay.`,
+    lastInput: normalizedKey
+  };
+}
+
+export function restartRevealRound(state: RevealRoundState): RevealRoundState {
+  return {
+    ...state,
+    phase: "ready",
+    feedbackTitle: "Ready to listen?",
+    feedbackBody: `Press Enter to hear the word, then type ${state.expectedKey.toUpperCase()}.`,
+    lastInput: null
+  };
+}

--- a/packages/runtime/src/scenes/BootScene.ts
+++ b/packages/runtime/src/scenes/BootScene.ts
@@ -38,7 +38,7 @@ export class BootScene extends Phaser.Scene {
   create() {
     const { width, height } = this.scale;
     const model = createBootSceneModel();
-    this.roundState = createRevealRoundState(model.item);
+    const roundSetup = createRevealRoundState(model.item);
 
     this.cameras.main.setBackgroundColor("#111927");
 
@@ -108,6 +108,16 @@ export class BootScene extends Phaser.Scene {
       })
       .setOrigin(0.5)
       .setVisible(false);
+
+    if (!roundSetup.ok) {
+      this.answerHintText.setText("This item needs a Latin-letter term before keyboard play can start.");
+      this.feedbackTitleText.setText("Content error");
+      this.feedbackTitleText.setColor(FAILURE_COLOR);
+      this.feedbackBodyText.setText(roundSetup.error.message);
+      return;
+    }
+
+    this.roundState = roundSetup.state;
 
     this.input.keyboard?.on("keydown", this.handleKeyDown, this);
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {

--- a/packages/runtime/src/scenes/BootScene.ts
+++ b/packages/runtime/src/scenes/BootScene.ts
@@ -1,37 +1,50 @@
 import Phaser from "phaser";
 import { createBootSceneModel } from "../demo-content";
+import {
+  createRevealRoundState,
+  judgeRevealRoundInput,
+  restartRevealRound,
+  startRevealRound,
+  type RevealRoundState
+} from "../reveal-round";
+
+const PANEL_FILL = 0x1d2638;
+const CARD_FILL = 0x24324a;
+const IMAGE_KEY = "demo-item-image";
+const AUDIO_KEY = "demo-item-audio";
+const SUCCESS_COLOR = "#7ef0ad";
+const FAILURE_COLOR = "#ff8b7c";
+const NEUTRAL_COLOR = "#ffcf88";
 
 export class BootScene extends Phaser.Scene {
+  private roundState!: RevealRoundState;
+  private feedbackTitleText!: Phaser.GameObjects.Text;
+  private feedbackBodyText!: Phaser.GameObjects.Text;
+  private cueLabelText!: Phaser.GameObjects.Text;
+  private answerHintText!: Phaser.GameObjects.Text;
+  private outcomeWordText!: Phaser.GameObjects.Text;
+
   constructor() {
     super("boot");
+  }
+
+  preload() {
+    const model = createBootSceneModel();
+
+    this.load.image(IMAGE_KEY, model.imageSrc);
+    this.load.audio(AUDIO_KEY, [model.audioSrc]);
   }
 
   create() {
     const { width, height } = this.scale;
     const model = createBootSceneModel();
+    this.roundState = createRevealRoundState(model.item);
 
     this.cameras.main.setBackgroundColor("#111927");
 
-    this.add.rectangle(width / 2, height / 2, width - 48, height - 48, 0x1d2638, 1);
+    this.add.rectangle(width / 2, height / 2, width - 48, height - 48, PANEL_FILL, 1);
     this.add
-      .text(width / 2, height / 2 - 70, model.headline, {
-        color: "#f6efe5",
-        fontFamily: "Trebuchet MS, Verdana, sans-serif",
-        fontSize: "32px",
-        fontStyle: "bold"
-      })
-      .setOrigin(0.5);
-
-    this.add
-      .text(width / 2, height / 2 - 18, model.subhead, {
-        color: "#ffcf88",
-        fontFamily: "Trebuchet MS, Verdana, sans-serif",
-        fontSize: "18px"
-      })
-      .setOrigin(0.5);
-
-    this.add
-      .text(width / 2, height / 2 + 30, `${model.term} - ${model.meaning}`, {
+      .text(width / 2, 58, model.headline, {
         color: "#f6efe5",
         fontFamily: "Trebuchet MS, Verdana, sans-serif",
         fontSize: "28px",
@@ -40,11 +53,128 @@ export class BootScene extends Phaser.Scene {
       .setOrigin(0.5);
 
     this.add
-      .text(width / 2, height / 2 + 72, "Runtime reads the first demo item through the loader seam.", {
+      .text(width / 2, 96, model.subhead, {
         color: "#ffcf88",
+        fontFamily: "Trebuchet MS, Verdana, sans-serif",
+        fontSize: "16px"
+      })
+      .setOrigin(0.5);
+
+    this.add.rectangle(width / 2, 260, 280, 280, CARD_FILL, 1).setStrokeStyle(2, 0xffcf88, 0.18);
+    this.add.image(width / 2, 260, IMAGE_KEY).setDisplaySize(220, 220);
+
+    this.cueLabelText = this.add
+      .text(width / 2, 420, `Visible cue: ${model.meaning}`, {
+        color: "#f6efe5",
+        fontFamily: "Trebuchet MS, Verdana, sans-serif",
+        fontSize: "26px",
+        fontStyle: "bold"
+      })
+      .setOrigin(0.5);
+
+    this.answerHintText = this.add
+      .text(width / 2, 454, "Listen for the English word, then type its first letter.", {
+        color: "#d6dee8",
         fontFamily: "Trebuchet MS, Verdana, sans-serif",
         fontSize: "18px"
       })
       .setOrigin(0.5);
+
+    this.feedbackTitleText = this.add
+      .text(width / 2, 492, "", {
+        color: NEUTRAL_COLOR,
+        fontFamily: "Trebuchet MS, Verdana, sans-serif",
+        fontSize: "24px",
+        fontStyle: "bold"
+      })
+      .setOrigin(0.5);
+
+    this.feedbackBodyText = this.add
+      .text(width / 2, 520, "", {
+        color: "#f6efe5",
+        fontFamily: "Trebuchet MS, Verdana, sans-serif",
+        fontSize: "16px",
+        align: "center",
+        wordWrap: { width: width - 120 }
+      })
+      .setOrigin(0.5);
+
+    this.outcomeWordText = this.add
+      .text(width / 2, 382, "", {
+        color: "#f6efe5",
+        fontFamily: "Trebuchet MS, Verdana, sans-serif",
+        fontSize: "22px",
+        fontStyle: "bold"
+      })
+      .setOrigin(0.5)
+      .setVisible(false);
+
+    this.input.keyboard?.on("keydown", this.handleKeyDown, this);
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      this.input.keyboard?.off("keydown", this.handleKeyDown, this);
+    });
+
+    this.renderRoundState();
+  }
+
+  private handleKeyDown = (event: KeyboardEvent) => {
+    const normalizedKey = event.key.toLowerCase();
+
+    if (normalizedKey === "enter") {
+      if (this.roundState.phase === "ready") {
+        this.roundState = startRevealRound(this.roundState);
+        this.playPronunciationCue();
+        this.renderRoundState();
+        return;
+      }
+
+      if (this.roundState.phase === "success" || this.roundState.phase === "failure") {
+        this.roundState = startRevealRound(restartRevealRound(this.roundState));
+        this.playPronunciationCue();
+        this.renderRoundState();
+      }
+
+      return;
+    }
+
+    const nextState = judgeRevealRoundInput(this.roundState, event.key);
+
+    if (nextState !== this.roundState) {
+      this.roundState = nextState;
+      this.renderRoundState();
+    }
+  };
+
+  private playPronunciationCue() {
+    this.sound.stopAll();
+    this.sound.play(AUDIO_KEY);
+  }
+
+  private renderRoundState() {
+    this.feedbackTitleText.setText(this.roundState.feedbackTitle);
+    this.feedbackBodyText.setText(this.roundState.feedbackBody);
+
+    switch (this.roundState.phase) {
+      case "ready":
+        this.feedbackTitleText.setColor(NEUTRAL_COLOR);
+        this.outcomeWordText.setVisible(false);
+        break;
+      case "awaiting-answer":
+        this.feedbackTitleText.setColor(NEUTRAL_COLOR);
+        this.outcomeWordText.setVisible(false);
+        break;
+      case "success":
+        this.feedbackTitleText.setColor(SUCCESS_COLOR);
+        this.outcomeWordText
+          .setText(`${this.roundState.termLabel} (${this.roundState.meaningLabel})`)
+          .setVisible(true);
+        break;
+      case "failure":
+        this.feedbackTitleText.setColor(FAILURE_COLOR);
+        this.outcomeWordText
+          .setText(`${this.roundState.termLabel} (${this.roundState.meaningLabel})`)
+          .setVisible(true);
+        break;
+    }
   }
 }


### PR DESCRIPTION
Closes #115
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the first playable reveal loop and checkpointed it in `288a687` on `codex/issue-115`. The Phaser scene now shows the demo image cue, waits for `Enter` to start the pronunciation cue, accepts the learner’s typed first-letter response, judges it as success or failure with visible on-screen feedback, and lets the learner replay with `Enter` without reloading. The behavior is driven by a small tested state boundary in [reveal-round.ts](/Users/tomoakikawada/Dev/FNE/FNE-codex-supervisor/.local/worktrees/issue-115/packages/runtime/src/reveal-round.ts), and the scene wiring lives in [BootScene.ts](/Users/tomoakikawada/Dev/FNE/FNE-codex-supervisor/.local/worktrees/issue-115/packages/runtime/src/scenes/BootScene.ts). The focused regression test is in [revealRound.test.ts](/Users/tomoakikawada/Dev/FNE/FNE-codex-supervisor/.local/worktrees/issue-115/apps/web/src/revealRound.test.ts).

Local gates are green: `pnpm test`, `pnpm typecheck`, and `pnpm lint` all passed. I also smoke-tested the loop in a real browser with keyboard-only input and confirmed the ready state, a failure case with `X`, and a success case with `A`. The remaining gap is audio confirmation by human listening; the browser flow triggers playback on `Enter`, but I did not independently verify the audible output with a human-ear check.

Summary: Added a tested audio-start, keyboard-judgment, success/failure, and replay loop for the demo item, with local gates passing and a real-browser keyboard smoke test co...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced reveal-round interactive lesson mode where users listen to audio pronunciation and type the first letter of vocabulary items.
  * Added visual feedback distinguishing correct vs. incorrect answers with clear success/failure indicators.
  * Enabled replay functionality allowing users to re-attempt without reloading.

* **Tests**
  * Added comprehensive test coverage for reveal-round state transitions and input judgment logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->