### PR TITLE
Epic 12.4 - Add minimal runtime state model for restartable local play (#116)

### DIFF
--- a/.codex-supervisor/issues/116/issue-journal.md
+++ b/.codex-supervisor/issues/116/issue-journal.md
@@ -1,0 +1,34 @@
+# Issue #116: Epic 12.4 - Add minimal runtime state model for restartable local play
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/FNE/issues/116
+- Branch: codex/issue-116
+- Workspace: .
+- Journal: .codex-supervisor/issues/116/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: c598cd693002ddabedf2e1552593c334454a51be
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-18T14:41:02.240Z
+
+## Latest Codex Summary
+- Reproduced the runtime-model gap with a focused `revealRound` test, then replaced the coarse `ready -> awaiting-answer -> success|failure` flow with an explicit `idle -> revealing -> awaiting-input -> judged` state machine plus separate `judgment` outcome. Updated `BootScene` to drive restart through those transitions and verified with targeted tests, `lint`, and `typecheck`.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The issue was not missing restart logic; it was that the authoritative runtime boundary still collapsed reveal, input, and terminal outcome into one coarse phase model, which made the loop less explicit than Epic 12.4 requires.
+- What changed: Added a focused failing test for explicit `idle/revealing/awaiting-input/judged` transitions and fail-closed invalid transitions. Reworked `packages/runtime/src/reveal-round.ts` to use those phases plus `judgment`, and updated `packages/runtime/src/scenes/BootScene.ts` to restart by returning to `idle`, beginning reveal, playing audio, then advancing into input.
+- Current blocker: none
+- Next exact step: Commit the state-model/test changes on `codex/issue-116`, then decide whether to open a draft PR now or continue with any additional local review the supervisor requests.
+- Verification gap: Manual browser confirmation of restart after both success and failure has not been run in this turn; automated runtime boundary coverage, `lint`, and `typecheck` are passing.
+- Files touched: apps/web/src/revealRound.test.ts; packages/runtime/src/reveal-round.ts; packages/runtime/src/scenes/BootScene.ts
+- Rollback concern: Low. The change is localized to the reveal-round state machine and its Phaser scene consumer, but any later code that still expects the old phase names would need updating.
+- Last focused command: `pnpm typecheck`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- Repro command after install: `pnpm test -- --run revealRound`

--- a/apps/web/src/revealRound.test.ts
+++ b/apps/web/src/revealRound.test.ts
@@ -1,58 +1,111 @@
 import {
+  advanceRevealRound,
+  beginRevealRound,
   createRevealRoundState,
   judgeRevealRoundInput,
   restartRevealRound,
-  startRevealRound
+  type RevealRoundState
 } from "@fne/runtime/reveal-round";
 import { describe, expect, it } from "vitest";
 
+function expectPlayableState(
+  setup: ReturnType<typeof createRevealRoundState>
+): RevealRoundState {
+  expect(setup.ok).toBe(true);
+
+  if (!setup.ok) {
+    throw new Error("expected a playable reveal round");
+  }
+
+  return setup.state;
+}
+
 describe("reveal round state", () => {
-  it("gates audio start, judges the typed first letter, and resets for replay", () => {
-    const setup = createRevealRoundState({
-      id: "apple",
-      term: "apple",
-      meaning: "りんご",
-      pronunciation: "AP-uhl",
-      imageAssetId: "img-apple",
-      audioAssetId: "aud-apple"
-    });
+  it("uses explicit idle, reveal, input, and judged states for the restartable loop", () => {
+    const state = expectPlayableState(
+      createRevealRoundState({
+        id: "apple",
+        term: "apple",
+        meaning: "りんご",
+        pronunciation: "AP-uhl",
+        imageAssetId: "img-apple",
+        audioAssetId: "aud-apple"
+      })
+    );
 
-    expect(setup.ok).toBe(true);
-
-    if (!setup.ok) {
-      throw new Error("expected a playable reveal round");
-    }
-
-    const state = setup.state;
-
-    expect(state.phase).toBe("ready");
+    expect(state.phase).toBe("idle");
+    expect(state.judgment).toBeNull();
     expect(state.expectedKey).toBe("a");
     expect(state.audioCueRequestCount).toBe(0);
-    expect(state.feedbackBody).toBe("Press Enter to hear the word, then type its first letter.");
 
-    const started = startRevealRound(state);
+    const revealing = beginRevealRound(state);
 
-    expect(started.phase).toBe("awaiting-answer");
-    expect(started.audioCueRequestCount).toBe(1);
-    expect(started.feedbackTitle).toBe("Type the first letter");
-    expect(started.feedbackBody).toBe("Listen for the word, then type its first letter.");
+    expect(revealing.phase).toBe("revealing");
+    expect(revealing.judgment).toBeNull();
+    expect(revealing.audioCueRequestCount).toBe(1);
+    expect(revealing.feedbackTitle).toBe("Listen to the word");
 
-    const failed = judgeRevealRoundInput(started, "x");
+    const awaitingInput = advanceRevealRound(revealing);
 
-    expect(failed.phase).toBe("failure");
+    expect(awaitingInput.phase).toBe("awaiting-input");
+    expect(awaitingInput.feedbackTitle).toBe("Type the first letter");
+    expect(awaitingInput.feedbackBody).toBe("Type the first letter of the word you just heard.");
+
+    const failed = judgeRevealRoundInput(awaitingInput, "x");
+
+    expect(failed.phase).toBe("judged");
+    expect(failed.judgment).toBe("failure");
     expect(failed.lastInput).toBe("x");
     expect(failed.feedbackBody).toContain("A");
     expect(failed.feedbackBody).toContain("X");
 
-    const replayReady = restartRevealRound(failed);
-    const replayStarted = startRevealRound(replayReady);
-    const succeeded = judgeRevealRoundInput(replayStarted, "A");
+    const restarted = restartRevealRound(failed);
 
-    expect(replayReady.phase).toBe("ready");
-    expect(replayStarted.audioCueRequestCount).toBe(2);
-    expect(succeeded.phase).toBe("success");
+    expect(restarted.phase).toBe("idle");
+    expect(restarted.judgment).toBeNull();
+    expect(restarted.audioCueRequestCount).toBe(1);
+
+    const replayRevealing = beginRevealRound(restarted);
+    const replayAwaitingInput = advanceRevealRound(replayRevealing);
+    const succeeded = judgeRevealRoundInput(replayAwaitingInput, "A");
+
+    expect(replayRevealing.audioCueRequestCount).toBe(2);
+    expect(succeeded.phase).toBe("judged");
+    expect(succeeded.judgment).toBe("success");
     expect(succeeded.feedbackBody).toContain("apple");
     expect(succeeded.feedbackBody).toContain("A");
+  });
+
+  it("fails closed on invalid transitions and keeps the current state unchanged", () => {
+    const idleState = expectPlayableState(
+      createRevealRoundState({
+        id: "apple",
+        term: "apple",
+        meaning: "りんご",
+        pronunciation: "AP-uhl",
+        imageAssetId: "img-apple",
+        audioAssetId: "aud-apple"
+      })
+    );
+
+    expect(advanceRevealRound(idleState)).toBe(idleState);
+    expect(judgeRevealRoundInput(idleState, "a")).toBe(idleState);
+    expect(restartRevealRound(idleState)).toBe(idleState);
+
+    const revealing = beginRevealRound(idleState);
+
+    expect(beginRevealRound(revealing)).toBe(revealing);
+    expect(judgeRevealRoundInput(revealing, "a")).toBe(revealing);
+    expect(restartRevealRound(revealing)).toBe(revealing);
+
+    const awaitingInput = advanceRevealRound(revealing);
+    const judged = judgeRevealRoundInput(awaitingInput, "a");
+
+    expect(advanceRevealRound(awaitingInput)).toBe(awaitingInput);
+    expect(beginRevealRound(awaitingInput)).toBe(awaitingInput);
+    expect(advanceRevealRound(judged)).toBe(judged);
+    expect(judgeRevealRoundInput(judged, "a")).toBe(judged);
+    expect(beginRevealRound(judged)).toBe(judged);
   });
 
   it("returns a recoverable content error when the term has no Latin letter", () => {

--- a/packages/runtime/src/reveal-round.ts
+++ b/packages/runtime/src/reveal-round.ts
@@ -1,6 +1,7 @@
 import type { VocabularyItem } from "@fne/shared";
 
-export type RevealRoundPhase = "ready" | "awaiting-answer" | "success" | "failure";
+export type RevealRoundPhase = "idle" | "revealing" | "awaiting-input" | "judged";
+export type RevealRoundJudgment = "success" | "failure";
 
 export interface RevealRoundState {
   itemId: string;
@@ -8,6 +9,7 @@ export interface RevealRoundState {
   meaningLabel: string;
   expectedKey: string;
   phase: RevealRoundPhase;
+  judgment: RevealRoundJudgment | null;
   audioCueRequestCount: number;
   feedbackTitle: string;
   feedbackBody: string;
@@ -73,7 +75,8 @@ export function createRevealRoundState(item: VocabularyItem): RevealRoundSetupRe
       termLabel: item.term,
       meaningLabel: item.meaning,
       expectedKey,
-      phase: "ready",
+      phase: "idle",
+      judgment: null,
       audioCueRequestCount: 0,
       feedbackTitle: "Ready to listen?",
       feedbackBody: "Press Enter to hear the word, then type its first letter.",
@@ -82,17 +85,32 @@ export function createRevealRoundState(item: VocabularyItem): RevealRoundSetupRe
   };
 }
 
-export function startRevealRound(state: RevealRoundState): RevealRoundState {
-  if (state.phase === "awaiting-answer") {
+export function beginRevealRound(state: RevealRoundState): RevealRoundState {
+  if (state.phase !== "idle") {
     return state;
   }
 
   return {
     ...state,
-    phase: "awaiting-answer",
+    phase: "revealing",
+    judgment: null,
     audioCueRequestCount: state.audioCueRequestCount + 1,
+    feedbackTitle: "Listen to the word",
+    feedbackBody: "The pronunciation cue is playing now.",
+    lastInput: null
+  };
+}
+
+export function advanceRevealRound(state: RevealRoundState): RevealRoundState {
+  if (state.phase !== "revealing") {
+    return state;
+  }
+
+  return {
+    ...state,
+    phase: "awaiting-input",
     feedbackTitle: "Type the first letter",
-    feedbackBody: "Listen for the word, then type its first letter.",
+    feedbackBody: "Type the first letter of the word you just heard.",
     lastInput: null
   };
 }
@@ -101,7 +119,7 @@ export function judgeRevealRoundInput(
   state: RevealRoundState,
   key: string
 ): RevealRoundState {
-  if (state.phase !== "awaiting-answer") {
+  if (state.phase !== "awaiting-input") {
     return state;
   }
 
@@ -114,7 +132,8 @@ export function judgeRevealRoundInput(
   if (normalizedKey === state.expectedKey) {
     return {
       ...state,
-      phase: "success",
+      phase: "judged",
+      judgment: "success",
       feedbackTitle: "Nice hit",
       feedbackBody: `${state.termLabel} starts with ${state.expectedKey.toUpperCase()}. Press Enter to replay.`,
       lastInput: normalizedKey
@@ -123,7 +142,8 @@ export function judgeRevealRoundInput(
 
   return {
     ...state,
-    phase: "failure",
+    phase: "judged",
+    judgment: "failure",
     feedbackTitle: "Not yet",
     feedbackBody: `${state.termLabel} starts with ${state.expectedKey.toUpperCase()}, not ${normalizedKey.toUpperCase()}. Press Enter to replay.`,
     lastInput: normalizedKey
@@ -131,9 +151,14 @@ export function judgeRevealRoundInput(
 }
 
 export function restartRevealRound(state: RevealRoundState): RevealRoundState {
+  if (state.phase !== "judged") {
+    return state;
+  }
+
   return {
     ...state,
-    phase: "ready",
+    phase: "idle",
+    judgment: null,
     feedbackTitle: "Ready to listen?",
     feedbackBody: "Press Enter to hear the word, then type its first letter.",
     lastInput: null

--- a/packages/runtime/src/scenes/BootScene.ts
+++ b/packages/runtime/src/scenes/BootScene.ts
@@ -1,10 +1,11 @@
 import Phaser from "phaser";
 import { createBootSceneModel } from "../demo-content";
 import {
+  advanceRevealRound,
+  beginRevealRound,
   createRevealRoundState,
   judgeRevealRoundInput,
   restartRevealRound,
-  startRevealRound,
   type RevealRoundState
 } from "../reveal-round";
 
@@ -131,16 +132,18 @@ export class BootScene extends Phaser.Scene {
     const normalizedKey = event.key.toLowerCase();
 
     if (normalizedKey === "enter") {
-      if (this.roundState.phase === "ready") {
-        this.roundState = startRevealRound(this.roundState);
-        this.playPronunciationCue();
-        this.renderRoundState();
-        return;
-      }
+      if (this.roundState.phase === "idle" || this.roundState.phase === "judged") {
+        const idleState =
+          this.roundState.phase === "judged"
+            ? restartRevealRound(this.roundState)
+            : this.roundState;
 
-      if (this.roundState.phase === "success" || this.roundState.phase === "failure") {
-        this.roundState = startRevealRound(restartRevealRound(this.roundState));
+        const revealingState = beginRevealRound(idleState);
+
+        this.roundState = revealingState;
+        this.renderRoundState();
         this.playPronunciationCue();
+        this.roundState = advanceRevealRound(revealingState);
         this.renderRoundState();
       }
 
@@ -165,22 +168,22 @@ export class BootScene extends Phaser.Scene {
     this.feedbackBodyText.setText(this.roundState.feedbackBody);
 
     switch (this.roundState.phase) {
-      case "ready":
+      case "idle":
         this.feedbackTitleText.setColor(NEUTRAL_COLOR);
         this.outcomeWordText.setVisible(false);
         break;
-      case "awaiting-answer":
+      case "revealing":
         this.feedbackTitleText.setColor(NEUTRAL_COLOR);
         this.outcomeWordText.setVisible(false);
         break;
-      case "success":
-        this.feedbackTitleText.setColor(SUCCESS_COLOR);
-        this.outcomeWordText
-          .setText(`${this.roundState.termLabel} (${this.roundState.meaningLabel})`)
-          .setVisible(true);
+      case "awaiting-input":
+        this.feedbackTitleText.setColor(NEUTRAL_COLOR);
+        this.outcomeWordText.setVisible(false);
         break;
-      case "failure":
-        this.feedbackTitleText.setColor(FAILURE_COLOR);
+      case "judged":
+        this.feedbackTitleText.setColor(
+          this.roundState.judgment === "success" ? SUCCESS_COLOR : FAILURE_COLOR
+        );
         this.outcomeWordText
           .setText(`${this.roundState.termLabel} (${this.roundState.meaningLabel})`)
           .setVisible(true);


### PR DESCRIPTION
Closes #116
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the minimal restartable runtime state machine and committed it as `ab2a69b` on `codex/issue-116`.

The authoritative runtime boundary in [packages/runtime/src/reveal-round.ts](/Users/tomoakikawada/Dev/FNE/FNE-codex-supervisor/.local/worktrees/issue-116/packages/runtime/src/reveal-round.ts) now uses explicit `idle -> revealing -> awaiting-input -> judged` phases with a separate `judgment` field, instead of folding reveal/input/outcome into coarse phases. [packages/runtime/src/scenes/BootScene.ts](/Users/tomoakikawada/Dev/FNE/FNE-codex-supervisor/.local/worktrees/issue-116/packages/runtime/src/scenes/BootScene.ts) was updated to restart through that state machine cleanly, and [apps/web/src/revealRound.test.ts](/Users/tomoakikawada/Dev/FNE/FNE-codex-supervisor/.local/worktrees/issue-116/apps/web/src/revealRound.test.ts) now proves the explicit transition sequence plus fail-closed invalid transitions. I also updated the issue journal with the repro, fix, and verification details.

I did not run a manual browser playtest in this turn, so the remaining gap is confirming restart behavior interactively after both success and failure outcomes.

Summary: Added an explicit minimal reveal-round runtime state machine with restart coverage, updated the Phaser scene to use it, verified with focused tests plus lint and typecheck, and committed the checkpoint as `ab2a69b`.
State hint: implementing
Blocked reason: none
Tests: `pnpm test -- --run revealRound`; `pnpm lint`; `pnpm ...