### PR TITLE
Epic 12.5 - Add implementation guardrails and smoke validation for runtime skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ The draft TypeScript compiler baseline lives in [docs/typescript-baseline.md](do
 The TypeScript compatibility review checklist lives in [docs/typescript-review-checklist.md](docs/typescript-review-checklist.md).
 The lint and typecheck gate expectations live in [docs/validation-gates.md](docs/validation-gates.md).
 
+## Local Validation
+Install dependencies with `pnpm install`, then use the repo validation scripts directly:
+
+- `pnpm run smoke:runtime` verifies the runtime skeleton still boots the Phaser shell and tears down cleanly.
+- `pnpm run typecheck` runs the TypeScript gate.
+- `pnpm run lint` runs the lint gate.
+
 ## Product Brief
 FNE is a rhythm-based vocabulary learning game for junior-high students who struggle with text-only study. It borrows the energy and clear feedback loop of Friday Night Funkin' so practice feels like play instead of a worksheet.
 

--- a/apps/web/src/runtimeSmoke.test.ts
+++ b/apps/web/src/runtimeSmoke.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { SHELL_HEIGHT_PX, SHELL_WIDTH_PX } from "@fne/shared";
+import {
+  createRuntimeGameConfig,
+  mountRuntimeWithGameCtor,
+  type RuntimeGameConfig,
+  type RuntimeGameHandle,
+  type RuntimePhaserApi
+} from "@fne/runtime/runtime-mount";
+
+describe("runtime smoke", () => {
+  it("builds a runtime game config and destroys the runtime cleanly", () => {
+    const container = document.createElement("div");
+    const destroySpy = vi.fn();
+    const fakeScene = { key: "boot-scene" };
+    const fakePhaserApi: RuntimePhaserApi = {
+      AUTO: "AUTO",
+      Scale: {
+        FIT: "FIT",
+        CENTER_BOTH: "CENTER_BOTH"
+      }
+    };
+    const capturedConfigs: RuntimeGameConfig<typeof fakeScene>[] = [];
+
+    class FakeGame implements RuntimeGameHandle {
+      constructor(config: RuntimeGameConfig<typeof fakeScene>) {
+        capturedConfigs.push(config);
+      }
+
+      destroy(removeCanvas?: boolean) {
+        destroySpy(removeCanvas);
+      }
+    }
+
+    const config = createRuntimeGameConfig(container, fakeScene, fakePhaserApi);
+    const runtime = mountRuntimeWithGameCtor(config, FakeGame);
+
+    expect(config).toMatchObject({
+      type: "AUTO",
+      parent: container,
+      width: SHELL_WIDTH_PX,
+      height: SHELL_HEIGHT_PX,
+      backgroundColor: "#111927",
+      scene: [fakeScene],
+      scale: {
+        mode: "FIT",
+        autoCenter: "CENTER_BOTH",
+        width: SHELL_WIDTH_PX,
+        height: SHELL_HEIGHT_PX
+      }
+    });
+    expect(capturedConfigs).toEqual([config]);
+
+    runtime.destroy();
+
+    expect(destroySpy).toHaveBeenCalledWith(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "lint": "pnpm exec eslint apps packages --ext .ts,.tsx",
+    "smoke:runtime": "pnpm --filter @fne/web test -- src/runtimeSmoke.test.ts",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm --filter @fne/web test"
   }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -6,7 +6,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./demo-content": "./src/demo-content.ts",
-    "./reveal-round": "./src/reveal-round.ts"
+    "./reveal-round": "./src/reveal-round.ts",
+    "./runtime-mount": "./src/runtime-mount.ts"
   },
   "scripts": {
     "typecheck": "tsc --project tsconfig.json --noEmit"

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,7 +1,15 @@
 import Phaser from "phaser";
-import { SHELL_HEIGHT_PX, SHELL_WIDTH_PX, type RuntimeMount } from "@fne/shared";
+import { type RuntimeMount } from "@fne/shared";
 import { BootScene } from "./scenes/BootScene";
+import {
+  createRuntimeGameConfig,
+  mountRuntimeWithGameCtor,
+  type RuntimeGameConfig,
+  type RuntimeGameConstructor,
+  type RuntimePhaserApi
+} from "./runtime-mount";
 
+export { BootScene } from "./scenes/BootScene";
 export {
   createBootSceneModel,
   loadDemoRuntimeItem,
@@ -9,26 +17,20 @@ export {
   type DemoRuntimeItemLoader,
   type RuntimeDemoItem
 } from "./demo-content";
+export {
+  createRuntimeGameConfig,
+  mountRuntimeWithGameCtor,
+  type RuntimeGameConfig,
+  type RuntimeGameConstructor,
+  type RuntimeGameHandle,
+  type RuntimePhaserApi
+} from "./runtime-mount";
 
 export function mountRuntime(container: HTMLElement): RuntimeMount {
-  const game = new Phaser.Game({
-    type: Phaser.AUTO,
-    parent: container,
-    backgroundColor: "#111927",
-    width: SHELL_WIDTH_PX,
-    height: SHELL_HEIGHT_PX,
-    scene: [BootScene],
-    scale: {
-      mode: Phaser.Scale.FIT,
-      autoCenter: Phaser.Scale.CENTER_BOTH,
-      width: SHELL_WIDTH_PX,
-      height: SHELL_HEIGHT_PX
-    }
-  });
+  const phaserApi: RuntimePhaserApi = Phaser;
+  const gameCtor =
+    Phaser.Game as unknown as RuntimeGameConstructor<RuntimeGameConfig<typeof BootScene>>;
+  const config = createRuntimeGameConfig(container, BootScene, phaserApi);
 
-  return {
-    destroy() {
-      game.destroy(true);
-    }
-  };
+  return mountRuntimeWithGameCtor(config, gameCtor);
 }

--- a/packages/runtime/src/runtime-mount.ts
+++ b/packages/runtime/src/runtime-mount.ts
@@ -1,0 +1,68 @@
+import { SHELL_HEIGHT_PX, SHELL_WIDTH_PX, type RuntimeMount } from "@fne/shared";
+
+export interface RuntimeGameHandle {
+  destroy(removeCanvas?: boolean): void;
+}
+
+export interface RuntimeGameConstructor<TConfig> {
+  new (config: TConfig): RuntimeGameHandle;
+}
+
+export interface RuntimeScaleApi {
+  FIT: unknown;
+  CENTER_BOTH: unknown;
+}
+
+export interface RuntimePhaserApi {
+  AUTO: unknown;
+  Scale: RuntimeScaleApi;
+}
+
+export interface RuntimeGameConfig<TScene> {
+  type: unknown;
+  parent: HTMLElement;
+  backgroundColor: string;
+  width: number;
+  height: number;
+  scene: TScene[];
+  scale: {
+    mode: unknown;
+    autoCenter: unknown;
+    width: number;
+    height: number;
+  };
+}
+
+export function createRuntimeGameConfig<TScene>(
+  container: HTMLElement,
+  scene: TScene,
+  phaserApi: RuntimePhaserApi
+): RuntimeGameConfig<TScene> {
+  return {
+    type: phaserApi.AUTO,
+    parent: container,
+    backgroundColor: "#111927",
+    width: SHELL_WIDTH_PX,
+    height: SHELL_HEIGHT_PX,
+    scene: [scene],
+    scale: {
+      mode: phaserApi.Scale.FIT,
+      autoCenter: phaserApi.Scale.CENTER_BOTH,
+      width: SHELL_WIDTH_PX,
+      height: SHELL_HEIGHT_PX
+    }
+  };
+}
+
+export function mountRuntimeWithGameCtor<TScene, TConfig extends RuntimeGameConfig<TScene>>(
+  config: TConfig,
+  GameCtor: RuntimeGameConstructor<TConfig>
+): RuntimeMount {
+  const game = new GameCtor(config);
+
+  return {
+    destroy() {
+      game.destroy(true);
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add a focused `smoke:runtime` validation path for the runtime skeleton
- extract a small runtime mount seam so the boot wiring can be smoke-tested without browser canvas dependencies
- document the local validation commands alongside the existing `typecheck` and `lint` gates

## Verification
- pnpm run smoke:runtime
- pnpm run typecheck
- pnpm run lint

Closes #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Local Validation" section to README with instructions for running repository validation checks using pnpm.

* **Tests**
  * Added runtime smoke test validating runtime configuration generation, game initialization, and proper lifecycle cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->