### PR TITLE
Epic 13.1: implement Learn Mode reveal timeline and item-step state machine

### DIFF
--- a/apps/web/src/revealRound.test.ts
+++ b/apps/web/src/revealRound.test.ts
@@ -21,7 +21,7 @@ function expectPlayableState(
 }
 
 describe("reveal round state", () => {
-  it("uses explicit idle, reveal, input, and judged states for the restartable loop", () => {
+  it("follows the Learn Mode cue order and records whether the item needed support", () => {
     const state = expectPlayableState(
       createRevealRoundState({
         id: "apple",
@@ -35,43 +35,62 @@ describe("reveal round state", () => {
 
     expect(state.phase).toBe("idle");
     expect(state.judgment).toBeNull();
+    expect(state.attemptCount).toBe(0);
+    expect(state.passedWithSupport).toBe(false);
     expect(state.expectedKey).toBe("a");
     expect(state.audioCueRequestCount).toBe(0);
 
-    const revealing = beginRevealRound(state);
+    const attentionCue = beginRevealRound(state);
 
-    expect(revealing.phase).toBe("revealing");
-    expect(revealing.judgment).toBeNull();
-    expect(revealing.audioCueRequestCount).toBe(1);
-    expect(revealing.feedbackTitle).toBe("Listen to the word");
+    expect(attentionCue.phase).toBe("attention-cue");
+    expect(attentionCue.judgment).toBeNull();
+    expect(attentionCue.attemptCount).toBe(1);
+    expect(attentionCue.audioCueRequestCount).toBe(0);
+    expect(attentionCue.feedbackTitle).toBe("Get ready");
 
-    const awaitingInput = advanceRevealRound(revealing);
+    const imageReveal = advanceRevealRound(attentionCue);
+    const pronunciationReveal = advanceRevealRound(imageReveal);
+    const textReveal = advanceRevealRound(pronunciationReveal);
+    const awaitingInput = advanceRevealRound(textReveal);
 
+    expect(imageReveal.phase).toBe("image-reveal");
+    expect(pronunciationReveal.phase).toBe("pronunciation-reveal");
+    expect(pronunciationReveal.audioCueRequestCount).toBe(1);
+    expect(textReveal.phase).toBe("text-reveal");
     expect(awaitingInput.phase).toBe("awaiting-input");
-    expect(awaitingInput.feedbackTitle).toBe("Type the first letter");
-    expect(awaitingInput.feedbackBody).toBe("Type the first letter of the word you just heard.");
+    expect(awaitingInput.feedbackTitle).toBe("Your turn");
+    expect(awaitingInput.feedbackBody).toContain("first letter");
 
     const failed = judgeRevealRoundInput(awaitingInput, "x");
 
-    expect(failed.phase).toBe("judged");
-    expect(failed.judgment).toBe("failure");
+    expect(failed.phase).toBe("retry-needed");
+    expect(failed.judgment).toBe("retry-needed");
     expect(failed.lastInput).toBe("x");
+    expect(failed.passedWithSupport).toBe(false);
     expect(failed.feedbackBody).toContain("A");
     expect(failed.feedbackBody).toContain("X");
+    expect(failed.feedbackBody).toContain("try again");
 
     const restarted = restartRevealRound(failed);
 
     expect(restarted.phase).toBe("idle");
     expect(restarted.judgment).toBeNull();
     expect(restarted.audioCueRequestCount).toBe(1);
+    expect(restarted.attemptCount).toBe(1);
+    expect(restarted.passedWithSupport).toBe(false);
 
-    const replayRevealing = beginRevealRound(restarted);
-    const replayAwaitingInput = advanceRevealRound(replayRevealing);
+    const replayAttentionCue = beginRevealRound(restarted);
+    const replayImageReveal = advanceRevealRound(replayAttentionCue);
+    const replayPronunciationReveal = advanceRevealRound(replayImageReveal);
+    const replayTextReveal = advanceRevealRound(replayPronunciationReveal);
+    const replayAwaitingInput = advanceRevealRound(replayTextReveal);
     const succeeded = judgeRevealRoundInput(replayAwaitingInput, "A");
 
-    expect(replayRevealing.audioCueRequestCount).toBe(2);
-    expect(succeeded.phase).toBe("judged");
+    expect(replayPronunciationReveal.audioCueRequestCount).toBe(2);
+    expect(succeeded.phase).toBe("passed");
     expect(succeeded.judgment).toBe("success");
+    expect(succeeded.attemptCount).toBe(2);
+    expect(succeeded.passedWithSupport).toBe(true);
     expect(succeeded.feedbackBody).toContain("apple");
     expect(succeeded.feedbackBody).toContain("A");
   });
@@ -92,20 +111,23 @@ describe("reveal round state", () => {
     expect(judgeRevealRoundInput(idleState, "a")).toBe(idleState);
     expect(restartRevealRound(idleState)).toBe(idleState);
 
-    const revealing = beginRevealRound(idleState);
+    const attentionCue = beginRevealRound(idleState);
 
-    expect(beginRevealRound(revealing)).toBe(revealing);
-    expect(judgeRevealRoundInput(revealing, "a")).toBe(revealing);
-    expect(restartRevealRound(revealing)).toBe(revealing);
+    expect(beginRevealRound(attentionCue)).toBe(attentionCue);
+    expect(judgeRevealRoundInput(attentionCue, "a")).toBe(attentionCue);
+    expect(restartRevealRound(attentionCue)).toBe(attentionCue);
 
-    const awaitingInput = advanceRevealRound(revealing);
-    const judged = judgeRevealRoundInput(awaitingInput, "a");
+    const imageReveal = advanceRevealRound(attentionCue);
+    const pronunciationReveal = advanceRevealRound(imageReveal);
+    const textReveal = advanceRevealRound(pronunciationReveal);
+    const awaitingInput = advanceRevealRound(textReveal);
+    const passed = judgeRevealRoundInput(awaitingInput, "a");
 
     expect(advanceRevealRound(awaitingInput)).toBe(awaitingInput);
     expect(beginRevealRound(awaitingInput)).toBe(awaitingInput);
-    expect(advanceRevealRound(judged)).toBe(judged);
-    expect(judgeRevealRoundInput(judged, "a")).toBe(judged);
-    expect(beginRevealRound(judged)).toBe(judged);
+    expect(advanceRevealRound(passed)).toBe(passed);
+    expect(judgeRevealRoundInput(passed, "a")).toBe(passed);
+    expect(beginRevealRound(passed)).toBe(passed);
   });
 
   it("returns a recoverable content error when the term has no Latin letter", () => {

--- a/packages/runtime/src/reveal-round.ts
+++ b/packages/runtime/src/reveal-round.ts
@@ -1,7 +1,15 @@
 import type { VocabularyItem } from "@fne/shared";
 
-export type RevealRoundPhase = "idle" | "revealing" | "awaiting-input" | "judged";
-export type RevealRoundJudgment = "success" | "failure";
+export type RevealRoundPhase =
+  | "idle"
+  | "attention-cue"
+  | "image-reveal"
+  | "pronunciation-reveal"
+  | "text-reveal"
+  | "awaiting-input"
+  | "retry-needed"
+  | "passed";
+export type RevealRoundJudgment = "success" | "retry-needed";
 
 export interface RevealRoundState {
   itemId: string;
@@ -10,6 +18,8 @@ export interface RevealRoundState {
   expectedKey: string;
   phase: RevealRoundPhase;
   judgment: RevealRoundJudgment | null;
+  attemptCount: number;
+  passedWithSupport: boolean;
   audioCueRequestCount: number;
   feedbackTitle: string;
   feedbackBody: string;
@@ -77,9 +87,11 @@ export function createRevealRoundState(item: VocabularyItem): RevealRoundSetupRe
       expectedKey,
       phase: "idle",
       judgment: null,
+      attemptCount: 0,
+      passedWithSupport: false,
       audioCueRequestCount: 0,
       feedbackTitle: "Ready to listen?",
-      feedbackBody: "Press Enter to hear the word, then type its first letter.",
+      feedbackBody: "Press Enter to start the next Learn Mode reveal.",
       lastInput: null
     }
   };
@@ -90,29 +102,64 @@ export function beginRevealRound(state: RevealRoundState): RevealRoundState {
     return state;
   }
 
+  const nextAttemptCount = state.attemptCount + 1;
+  const isSupportedRepeat = nextAttemptCount > 1;
+
   return {
     ...state,
-    phase: "revealing",
+    phase: "attention-cue",
     judgment: null,
-    audioCueRequestCount: state.audioCueRequestCount + 1,
-    feedbackTitle: "Listen to the word",
-    feedbackBody: "The pronunciation cue is playing now.",
+    attemptCount: nextAttemptCount,
+    passedWithSupport: false,
+    feedbackTitle: "Get ready",
+    feedbackBody: isSupportedRepeat
+      ? "Try the same word again with the image and sound cue."
+      : "A new word is about to begin.",
     lastInput: null
   };
 }
 
 export function advanceRevealRound(state: RevealRoundState): RevealRoundState {
-  if (state.phase !== "revealing") {
-    return state;
+  switch (state.phase) {
+    case "attention-cue":
+      return {
+        ...state,
+        phase: "image-reveal",
+        feedbackTitle: "Look at the image",
+        feedbackBody: "Use the picture as your first meaning cue.",
+        lastInput: null
+      };
+    case "image-reveal":
+      return {
+        ...state,
+        phase: "pronunciation-reveal",
+        audioCueRequestCount: state.audioCueRequestCount + 1,
+        feedbackTitle: "Listen to the word",
+        feedbackBody:
+          state.attemptCount > 1
+            ? "Hear the pronunciation again, then get ready to answer."
+            : "Hear the pronunciation before the word text appears.",
+        lastInput: null
+      };
+    case "pronunciation-reveal":
+      return {
+        ...state,
+        phase: "text-reveal",
+        feedbackTitle: "Now read it",
+        feedbackBody: `The word is ${state.termLabel}.`,
+        lastInput: null
+      };
+    case "text-reveal":
+      return {
+        ...state,
+        phase: "awaiting-input",
+        feedbackTitle: "Your turn",
+        feedbackBody: "Type the first letter of the word you just heard.",
+        lastInput: null
+      };
+    default:
+      return state;
   }
-
-  return {
-    ...state,
-    phase: "awaiting-input",
-    feedbackTitle: "Type the first letter",
-    feedbackBody: "Type the first letter of the word you just heard.",
-    lastInput: null
-  };
 }
 
 export function judgeRevealRoundInput(
@@ -132,26 +179,30 @@ export function judgeRevealRoundInput(
   if (normalizedKey === state.expectedKey) {
     return {
       ...state,
-      phase: "judged",
+      phase: "passed",
       judgment: "success",
-      feedbackTitle: "Nice hit",
-      feedbackBody: `${state.termLabel} starts with ${state.expectedKey.toUpperCase()}. Press Enter to replay.`,
+      passedWithSupport: state.attemptCount > 1,
+      feedbackTitle: state.attemptCount > 1 ? "Nice recovery" : "Nice hit",
+      feedbackBody:
+        state.attemptCount > 1
+          ? `${state.termLabel} starts with ${state.expectedKey.toUpperCase()}. You cleared it after a supported repeat. Press Enter to replay the demo item.`
+          : `${state.termLabel} starts with ${state.expectedKey.toUpperCase()}. Press Enter to replay the demo item.`,
       lastInput: normalizedKey
     };
   }
 
   return {
     ...state,
-    phase: "judged",
-    judgment: "failure",
-    feedbackTitle: "Not yet",
-    feedbackBody: `${state.termLabel} starts with ${state.expectedKey.toUpperCase()}, not ${normalizedKey.toUpperCase()}. Press Enter to replay.`,
+    phase: "retry-needed",
+    judgment: "retry-needed",
+    feedbackTitle: "Try again",
+    feedbackBody: `${state.termLabel} starts with ${state.expectedKey.toUpperCase()}, not ${normalizedKey.toUpperCase()}. Press Enter to try again with the guided reveal.`,
     lastInput: normalizedKey
   };
 }
 
 export function restartRevealRound(state: RevealRoundState): RevealRoundState {
-  if (state.phase !== "judged") {
+  if (state.phase !== "retry-needed" && state.phase !== "passed") {
     return state;
   }
 
@@ -159,8 +210,9 @@ export function restartRevealRound(state: RevealRoundState): RevealRoundState {
     ...state,
     phase: "idle",
     judgment: null,
+    passedWithSupport: false,
     feedbackTitle: "Ready to listen?",
-    feedbackBody: "Press Enter to hear the word, then type its first letter.",
+    feedbackBody: "Press Enter to start the next Learn Mode reveal.",
     lastInput: null
   };
 }

--- a/packages/runtime/src/scenes/BootScene.ts
+++ b/packages/runtime/src/scenes/BootScene.ts
@@ -132,18 +132,26 @@ export class BootScene extends Phaser.Scene {
     const normalizedKey = event.key.toLowerCase();
 
     if (normalizedKey === "enter") {
-      if (this.roundState.phase === "idle" || this.roundState.phase === "judged") {
+      if (
+        this.roundState.phase === "idle" ||
+        this.roundState.phase === "retry-needed" ||
+        this.roundState.phase === "passed"
+      ) {
         const idleState =
-          this.roundState.phase === "judged"
-            ? restartRevealRound(this.roundState)
-            : this.roundState;
+          this.roundState.phase === "idle" ? this.roundState : restartRevealRound(this.roundState);
 
-        const revealingState = beginRevealRound(idleState);
+        const attentionCueState = beginRevealRound(idleState);
 
-        this.roundState = revealingState;
+        this.roundState = attentionCueState;
+        this.renderRoundState();
+        this.roundState = advanceRevealRound(this.roundState);
+        this.renderRoundState();
+        this.roundState = advanceRevealRound(this.roundState);
         this.renderRoundState();
         this.playPronunciationCue();
-        this.roundState = advanceRevealRound(revealingState);
+        this.roundState = advanceRevealRound(this.roundState);
+        this.renderRoundState();
+        this.roundState = advanceRevealRound(this.roundState);
         this.renderRoundState();
       }
 
@@ -172,15 +180,35 @@ export class BootScene extends Phaser.Scene {
         this.feedbackTitleText.setColor(NEUTRAL_COLOR);
         this.outcomeWordText.setVisible(false);
         break;
-      case "revealing":
+      case "attention-cue":
         this.feedbackTitleText.setColor(NEUTRAL_COLOR);
         this.outcomeWordText.setVisible(false);
+        break;
+      case "image-reveal":
+        this.feedbackTitleText.setColor(NEUTRAL_COLOR);
+        this.outcomeWordText.setVisible(false);
+        break;
+      case "pronunciation-reveal":
+        this.feedbackTitleText.setColor(NEUTRAL_COLOR);
+        this.outcomeWordText.setVisible(false);
+        break;
+      case "text-reveal":
+        this.feedbackTitleText.setColor(NEUTRAL_COLOR);
+        this.outcomeWordText.setVisible(true);
+        this.outcomeWordText.setText(`${this.roundState.termLabel} (${this.roundState.meaningLabel})`);
         break;
       case "awaiting-input":
         this.feedbackTitleText.setColor(NEUTRAL_COLOR);
-        this.outcomeWordText.setVisible(false);
+        this.outcomeWordText.setText(`${this.roundState.termLabel} (${this.roundState.meaningLabel})`);
+        this.outcomeWordText.setVisible(true);
         break;
-      case "judged":
+      case "retry-needed":
+        this.feedbackTitleText.setColor(FAILURE_COLOR);
+        this.outcomeWordText
+          .setText(`${this.roundState.termLabel} (${this.roundState.meaningLabel})`)
+          .setVisible(true);
+        break;
+      case "passed":
         this.feedbackTitleText.setColor(
           this.roundState.judgment === "success" ? SUCCESS_COLOR : FAILURE_COLOR
         );


### PR DESCRIPTION
## Summary
- encode the Learn Mode reveal order as explicit runtime phases
- track retry-needed versus supported-repeat clears per item
- update the demo BootScene to walk through attention, image, pronunciation, text, and prompt in order

## Verification
- pnpm --filter @fne/web test -- src/revealRound.test.ts
- pnpm typecheck
- pnpm lint

Closes #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reveal round flow now features a guided four-step progression with distinct attention cue, image reveal, pronunciation reveal, and text reveal stages for a more structured experience.
  * Enhanced UI displays word definitions during reveal and completion stages.
  * Improved attempt tracking and progress recognition for clearer learning feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->