### PR TITLE
[codex] Implement Learn Mode stage progression

### DIFF
--- a/apps/web/src/learnStage.test.ts
+++ b/apps/web/src/learnStage.test.ts
@@ -1,0 +1,182 @@
+import {
+  advanceLearnStageRound,
+  beginLearnStageRound,
+  continueLearnStage,
+  createLearnStageState,
+  judgeLearnStageInput,
+  restartLearnStageRound,
+  type LearnStageProgressState
+} from "@fne/runtime/learn-stage";
+import type { RuntimeStage } from "@fne/runtime/demo-content";
+import { describe, expect, it } from "vitest";
+
+function createFixtureStage(): RuntimeStage {
+  return {
+    packId: "demo-pack",
+    stageId: "stage-fruit-1",
+    items: [
+      {
+        packId: "demo-pack",
+        stageId: "stage-fruit-1",
+        item: {
+          id: "apple",
+          term: "apple",
+          meaning: "りんご",
+          pronunciation: "AP-uhl",
+          imageAssetId: "img-apple",
+          audioAssetId: "aud-apple"
+        },
+        imageSrc: "/content/packs/demo-pack/assets/images/img-apple.svg",
+        audioSrc: "/content/packs/demo-pack/assets/audio/aud-apple.wav"
+      },
+      {
+        packId: "demo-pack",
+        stageId: "stage-fruit-1",
+        item: {
+          id: "melon",
+          term: "melon",
+          meaning: "メロン",
+          pronunciation: "MEH-luhn",
+          imageAssetId: "img-melon",
+          audioAssetId: "aud-melon"
+        },
+        imageSrc: "/content/packs/demo-pack/assets/images/img-melon.svg",
+        audioSrc: "/content/packs/demo-pack/assets/audio/aud-melon.wav"
+      },
+      {
+        packId: "demo-pack",
+        stageId: "stage-fruit-1",
+        item: {
+          id: "banana",
+          term: "banana",
+          meaning: "バナナ",
+          pronunciation: "buh-NA-nuh",
+          imageAssetId: "img-banana",
+          audioAssetId: "aud-banana"
+        },
+        imageSrc: "/content/packs/demo-pack/assets/images/img-banana.svg",
+        audioSrc: "/content/packs/demo-pack/assets/audio/aud-banana.wav"
+      }
+    ]
+  };
+}
+
+function expectInProgressState(
+  state: ReturnType<typeof createLearnStageState>
+): LearnStageProgressState {
+  expect(state.kind).toBe("in-progress");
+
+  if (state.kind !== "in-progress") {
+    throw new Error("expected an in-progress learn stage");
+  }
+
+  return state;
+}
+
+function moveToAwaitingInput(state: LearnStageProgressState): LearnStageProgressState {
+  const attentionCue = beginLearnStageRound(state);
+  const imageReveal = advanceLearnStageRound(attentionCue);
+  const pronunciationReveal = advanceLearnStageRound(imageReveal);
+  const textReveal = advanceLearnStageRound(pronunciationReveal);
+  const awaitingInput = advanceLearnStageRound(textReveal);
+
+  expect(awaitingInput.kind).toBe("in-progress");
+
+  if (awaitingInput.kind !== "in-progress") {
+    throw new Error("expected an in-progress learn stage");
+  }
+
+  expect(awaitingInput.roundState.phase).toBe("awaiting-input");
+
+  return awaitingInput;
+}
+
+describe("learn stage state", () => {
+  it("advances to the next item only after the current item is passed", () => {
+    const stage = expectInProgressState(createLearnStageState(createFixtureStage()));
+    const awaitingInput = moveToAwaitingInput(stage);
+    const failed = judgeLearnStageInput(awaitingInput, "x");
+
+    expect(failed.kind).toBe("in-progress");
+
+    if (failed.kind !== "in-progress") {
+      throw new Error("expected an in-progress learn stage");
+    }
+
+    expect(failed.roundState.phase).toBe("retry-needed");
+    expect(continueLearnStage(failed)).toBe(failed);
+
+    const replayIdle = restartLearnStageRound(failed);
+    const replayAwaitingInput = moveToAwaitingInput(expectInProgressState(replayIdle));
+    const passed = judgeLearnStageInput(replayAwaitingInput, "a");
+
+    expect(passed.kind).toBe("in-progress");
+
+    if (passed.kind !== "in-progress") {
+      throw new Error("expected an in-progress learn stage");
+    }
+
+    expect(passed.roundState.phase).toBe("passed");
+
+    const nextItem = continueLearnStage(passed);
+
+    expect(nextItem.kind).toBe("in-progress");
+
+    if (nextItem.kind !== "in-progress") {
+      throw new Error("expected an in-progress learn stage");
+    }
+
+    expect(nextItem.currentIndex).toBe(1);
+    expect(nextItem.currentItem.item.id).toBe("melon");
+    expect(nextItem.completedItems).toEqual([
+      {
+        itemId: "apple",
+        passedWithSupport: true,
+        attemptCount: 2
+      }
+    ]);
+  });
+
+  it("completes the stage after all scheduled items are passed in order", () => {
+    let state = createLearnStageState(createFixtureStage());
+
+    for (const expectedKey of ["a", "m", "b"]) {
+      const awaitingInput = moveToAwaitingInput(expectInProgressState(state));
+      const passed = judgeLearnStageInput(awaitingInput, expectedKey);
+
+      expect(passed.kind).toBe("in-progress");
+
+      if (passed.kind !== "in-progress") {
+        throw new Error("expected an in-progress learn stage");
+      }
+
+      expect(passed.roundState.phase).toBe("passed");
+      state = continueLearnStage(passed);
+    }
+
+    expect(state.kind).toBe("summary");
+
+    if (state.kind !== "summary") {
+      throw new Error("expected a summary learn stage");
+    }
+
+    expect(state.totalItemCount).toBe(3);
+    expect(state.completedItems).toEqual([
+      {
+        itemId: "apple",
+        passedWithSupport: false,
+        attemptCount: 1
+      },
+      {
+        itemId: "melon",
+        passedWithSupport: false,
+        attemptCount: 1
+      },
+      {
+        itemId: "banana",
+        passedWithSupport: false,
+        attemptCount: 1
+      }
+    ]);
+  });
+});

--- a/apps/web/src/runtimeContent.test.ts
+++ b/apps/web/src/runtimeContent.test.ts
@@ -7,34 +7,43 @@ import {
 import {
   createBootSceneModel,
   loadDemoRuntimeItem,
-  loadRuntimeItemFromManifest
+  loadRuntimeItemFromManifest,
+  loadRuntimeStageFromManifest
 } from "@fne/runtime/demo-content";
 import { describe, expect, it, vi } from "vitest";
 
 describe("demo runtime content", () => {
   it("builds the boot scene model from a loader seam", () => {
-    const item: VocabularyItem = {
-      id: "banana",
-      term: "banana",
-      meaning: "バナナ",
-      pronunciation: "buh-NA-nuh",
-      imageAssetId: "img-banana",
-      audioAssetId: "aud-banana"
-    };
     const loader = vi.fn(() => ({
       packId: "demo-pack",
       stageId: "stage-fruit-1",
-      item,
-      imageSrc: "/content/packs/demo-pack/assets/images/img-banana.svg",
-      audioSrc: "/content/packs/demo-pack/assets/audio/aud-banana.wav"
+      items: [
+        {
+          packId: "demo-pack",
+          stageId: "stage-fruit-1",
+          item: {
+            id: "banana",
+            term: "banana",
+            meaning: "バナナ",
+            pronunciation: "buh-NA-nuh",
+            imageAssetId: "img-banana",
+            audioAssetId: "aud-banana"
+          },
+          imageSrc: "/content/packs/demo-pack/assets/images/img-banana.svg",
+          audioSrc: "/content/packs/demo-pack/assets/audio/aud-banana.wav"
+        }
+      ]
     }));
 
     const model = createBootSceneModel(loader);
 
     expect(loader).toHaveBeenCalledTimes(1);
-    expect(model.term).toBe("banana");
-    expect(model.meaning).toBe("バナナ");
-    expect(model.audioSrc).toBe("/content/packs/demo-pack/assets/audio/aud-banana.wav");
+    expect(model.packId).toBe("demo-pack");
+    expect(model.stageId).toBe("stage-fruit-1");
+    expect(model.items).toHaveLength(1);
+    expect(model.items[0]?.item.term).toBe("banana");
+    expect(model.items[0]?.item.meaning).toBe("バナナ");
+    expect(model.items[0]?.audioSrc).toBe("/content/packs/demo-pack/assets/audio/aud-banana.wav");
   });
 
   it("loads one demo item with canonical item fields and convention-aligned asset paths", () => {
@@ -94,6 +103,71 @@ describe("demo runtime content", () => {
     expect(runtimeItem.item.id).toBe("apple");
     expect(runtimeItem.imageSrc).toBe("/content/packs/demo-pack/assets/images/img-apple.svg");
     expect(runtimeItem.audioSrc).toBe("/content/packs/demo-pack/assets/audio/aud-apple.wav");
+  });
+
+  it("loads a short ordered runtime stage from stage item references", () => {
+    const manifest: PackManifest = {
+      schemaVersion: 1,
+      id: "demo-pack",
+      title: "Demo Pack",
+      description: "fixture",
+      vocabularyItems: [
+        {
+          id: "banana",
+          term: "banana",
+          meaning: "バナナ",
+          pronunciation: "buh-NA-nuh",
+          imageAssetId: "img-banana",
+          audioAssetId: "aud-banana"
+        },
+        {
+          id: "apple",
+          term: "apple",
+          meaning: "りんご",
+          pronunciation: "AP-uhl",
+          imageAssetId: "img-apple",
+          audioAssetId: "aud-apple"
+        },
+        {
+          id: "melon",
+          term: "melon",
+          meaning: "メロン",
+          pronunciation: "MEH-luhn",
+          imageAssetId: "img-melon",
+          audioAssetId: "aud-melon"
+        }
+      ],
+      stages: [
+        {
+          id: "stage-fruit-1",
+          title: "Fruit Basics",
+          vocabularyItemIds: ["apple", "melon", "banana"],
+          modeIds: ["practice"]
+        }
+      ],
+      modes: [
+        {
+          id: "practice",
+          label: "Practice",
+          description: "fixture"
+        }
+      ]
+    };
+
+    const runtimeStage = loadRuntimeStageFromManifest(manifest);
+
+    expect(runtimeStage.stageId).toBe("stage-fruit-1");
+    expect(runtimeStage.items.map((item) => item.item.id)).toEqual(["apple", "melon", "banana"]);
+    expect(runtimeStage.items.map((item) => item.imageSrc)).toEqual([
+      "/content/packs/demo-pack/assets/images/img-apple.svg",
+      "/content/packs/demo-pack/assets/images/img-melon.svg",
+      "/content/packs/demo-pack/assets/images/img-banana.svg"
+    ]);
+    expect(runtimeStage.items.map((item) => item.audioSrc)).toEqual([
+      "/content/packs/demo-pack/assets/audio/aud-apple.wav",
+      "/content/packs/demo-pack/assets/audio/aud-melon.wav",
+      "/content/packs/demo-pack/assets/audio/aud-banana.wav"
+    ]);
   });
 
   it("reports pack-specific validation errors instead of vocabulary-item prefixes", () => {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./demo-content": "./src/demo-content.ts",
+    "./learn-stage": "./src/learn-stage.ts",
     "./reveal-round": "./src/reveal-round.ts",
     "./runtime-mount": "./src/runtime-mount.ts"
   },

--- a/packages/runtime/src/demo-content.ts
+++ b/packages/runtime/src/demo-content.ts
@@ -14,16 +14,21 @@ export interface RuntimeDemoItem {
   audioSrc: string;
 }
 
-export interface BootSceneModel extends RuntimeDemoItem {
+export interface RuntimeStage {
+  packId: string;
+  stageId: string;
+  items: RuntimeDemoItem[];
+}
+
+export interface BootSceneModel extends RuntimeStage {
   headline: string;
   subhead: string;
-  term: string;
-  meaning: string;
 }
 
 type AssetDirectory = "images" | "audio";
 
 export type DemoRuntimeItemLoader = () => RuntimeDemoItem;
+export type DemoRuntimeStageLoader = () => RuntimeStage;
 
 assertValidPackManifest(demoPackManifestJson);
 const DEMO_PACK_MANIFEST = demoPackManifestJson;
@@ -37,50 +42,69 @@ function createAssetPath(
   return `/content/packs/${packId}/assets/${assetDirectory}/${assetId}.${extension}`;
 }
 
-export function loadRuntimeItemFromManifest(manifest: PackManifest): RuntimeDemoItem {
+export function loadRuntimeStageFromManifest(manifest: PackManifest): RuntimeStage {
   const stage = manifest.stages[0];
 
   if (stage === undefined) {
     throw new Error(`Pack "${manifest.id}" must contain at least one stage.`);
   }
 
-  const stageItemId = stage.vocabularyItemIds[0];
-
-  if (stageItemId === undefined) {
+  if (stage.vocabularyItemIds[0] === undefined) {
     throw new Error(`Stage "${stage.id}" must reference at least one vocabulary item id.`);
   }
 
-  const item = manifest.vocabularyItems.find((candidate) => candidate.id === stageItemId);
+  const items = stage.vocabularyItemIds.map((stageItemId) => {
+    const item = manifest.vocabularyItems.find((candidate) => candidate.id === stageItemId);
 
-  if (item === undefined) {
-    throw new Error(`Stage "${stage.id}" references unknown vocabulary item "${stageItemId}".`);
-  }
+    if (item === undefined) {
+      throw new Error(`Stage "${stage.id}" references unknown vocabulary item "${stageItemId}".`);
+    }
 
-  assertValidVocabularyItem(item);
+    assertValidVocabularyItem(item);
+
+    return {
+      packId: manifest.id,
+      stageId: stage.id,
+      item,
+      imageSrc: createAssetPath(manifest.id, "images", item.imageAssetId, "svg"),
+      audioSrc: createAssetPath(manifest.id, "audio", item.audioAssetId, "wav")
+    };
+  });
 
   return {
     packId: manifest.id,
     stageId: stage.id,
-    item,
-    imageSrc: createAssetPath(manifest.id, "images", item.imageAssetId, "svg"),
-    audioSrc: createAssetPath(manifest.id, "audio", item.audioAssetId, "wav")
+    items
   };
+}
+
+export function loadRuntimeItemFromManifest(manifest: PackManifest): RuntimeDemoItem {
+  const stage = loadRuntimeStageFromManifest(manifest);
+  const firstItem = stage.items[0];
+
+  if (firstItem === undefined) {
+    throw new Error(`Stage "${stage.stageId}" must reference at least one vocabulary item id.`);
+  }
+
+  return firstItem;
 }
 
 export function loadDemoRuntimeItem(): RuntimeDemoItem {
   return loadRuntimeItemFromManifest(DEMO_PACK_MANIFEST);
 }
 
+export function loadDemoRuntimeStage(): RuntimeStage {
+  return loadRuntimeStageFromManifest(DEMO_PACK_MANIFEST);
+}
+
 export function createBootSceneModel(
-  loadRuntimeItem: DemoRuntimeItemLoader = loadDemoRuntimeItem
+  loadRuntimeStage: DemoRuntimeStageLoader = loadDemoRuntimeStage
 ): BootSceneModel {
-  const runtimeItem = loadRuntimeItem();
+  const runtimeStage = loadRuntimeStage();
 
   return {
-    ...runtimeItem,
+    ...runtimeStage,
     headline: "Loader seam demo",
-    subhead: `Pack ${runtimeItem.packId} / Stage ${runtimeItem.stageId}`,
-    term: runtimeItem.item.term,
-    meaning: runtimeItem.item.meaning
+    subhead: `Pack ${runtimeStage.packId} / Stage ${runtimeStage.stageId}`
   };
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -12,11 +12,28 @@ import {
 export { BootScene } from "./scenes/BootScene";
 export {
   createBootSceneModel,
+  loadDemoRuntimeStage,
   loadDemoRuntimeItem,
+  loadRuntimeStageFromManifest,
   type BootSceneModel,
   type DemoRuntimeItemLoader,
-  type RuntimeDemoItem
+  type DemoRuntimeStageLoader,
+  type RuntimeDemoItem,
+  type RuntimeStage
 } from "./demo-content";
+export {
+  advanceLearnStageRound,
+  beginLearnStageRound,
+  continueLearnStage,
+  createLearnStageState,
+  judgeLearnStageInput,
+  restartLearnStageRound,
+  type LearnStageContentErrorState,
+  type LearnStageItemResult,
+  type LearnStageProgressState,
+  type LearnStageState,
+  type LearnStageSummaryState
+} from "./learn-stage";
 export {
   createRuntimeGameConfig,
   mountRuntimeWithGameCtor,

--- a/packages/runtime/src/learn-stage.ts
+++ b/packages/runtime/src/learn-stage.ts
@@ -1,0 +1,162 @@
+import type { RuntimeDemoItem, RuntimeStage } from "./demo-content";
+import {
+  advanceRevealRound,
+  beginRevealRound,
+  createRevealRoundState,
+  judgeRevealRoundInput,
+  restartRevealRound,
+  type RevealRoundContentError,
+  type RevealRoundState
+} from "./reveal-round";
+
+export interface LearnStageItemResult {
+  itemId: string;
+  passedWithSupport: boolean;
+  attemptCount: number;
+}
+
+export interface LearnStageProgressState {
+  kind: "in-progress";
+  packId: string;
+  stageId: string;
+  items: RuntimeDemoItem[];
+  currentIndex: number;
+  currentItem: RuntimeDemoItem;
+  roundState: RevealRoundState;
+  completedItems: LearnStageItemResult[];
+}
+
+export interface LearnStageSummaryState {
+  kind: "summary";
+  packId: string;
+  stageId: string;
+  completedItems: LearnStageItemResult[];
+  totalItemCount: number;
+}
+
+export interface LearnStageContentErrorState {
+  kind: "content-error";
+  packId: string;
+  stageId: string;
+  error: RevealRoundContentError;
+}
+
+export type LearnStageState =
+  | LearnStageProgressState
+  | LearnStageSummaryState
+  | LearnStageContentErrorState;
+
+function createItemResult(roundState: RevealRoundState): LearnStageItemResult {
+  return {
+    itemId: roundState.itemId,
+    passedWithSupport: roundState.passedWithSupport,
+    attemptCount: roundState.attemptCount
+  };
+}
+
+function createProgressState(
+  stage: RuntimeStage,
+  currentIndex: number,
+  completedItems: LearnStageItemResult[]
+): LearnStageState {
+  const currentItem = stage.items[currentIndex];
+
+  if (currentItem === undefined) {
+    return {
+      kind: "summary",
+      packId: stage.packId,
+      stageId: stage.stageId,
+      completedItems,
+      totalItemCount: stage.items.length
+    };
+  }
+
+  const roundSetup = createRevealRoundState(currentItem.item);
+
+  if (!roundSetup.ok) {
+    return {
+      kind: "content-error",
+      packId: stage.packId,
+      stageId: stage.stageId,
+      error: roundSetup.error
+    };
+  }
+
+  return {
+    kind: "in-progress",
+    packId: stage.packId,
+    stageId: stage.stageId,
+    items: stage.items,
+    currentIndex,
+    currentItem,
+    roundState: roundSetup.state,
+    completedItems
+  };
+}
+
+export function createLearnStageState(stage: RuntimeStage): LearnStageState {
+  return createProgressState(stage, 0, []);
+}
+
+export function beginLearnStageRound(state: LearnStageState): LearnStageState {
+  if (state.kind !== "in-progress") {
+    return state;
+  }
+
+  return {
+    ...state,
+    roundState: beginRevealRound(state.roundState)
+  };
+}
+
+export function advanceLearnStageRound(state: LearnStageState): LearnStageState {
+  if (state.kind !== "in-progress") {
+    return state;
+  }
+
+  return {
+    ...state,
+    roundState: advanceRevealRound(state.roundState)
+  };
+}
+
+export function judgeLearnStageInput(state: LearnStageState, key: string): LearnStageState {
+  if (state.kind !== "in-progress") {
+    return state;
+  }
+
+  return {
+    ...state,
+    roundState: judgeRevealRoundInput(state.roundState, key)
+  };
+}
+
+export function restartLearnStageRound(state: LearnStageState): LearnStageState {
+  if (state.kind !== "in-progress") {
+    return state;
+  }
+
+  return {
+    ...state,
+    roundState: restartRevealRound(state.roundState)
+  };
+}
+
+export function continueLearnStage(state: LearnStageState): LearnStageState {
+  if (state.kind !== "in-progress" || state.roundState.phase !== "passed") {
+    return state;
+  }
+
+  const completedItems = [...state.completedItems, createItemResult(state.roundState)];
+  const nextIndex = state.currentIndex + 1;
+
+  return createProgressState(
+    {
+      packId: state.packId,
+      stageId: state.stageId,
+      items: state.items
+    },
+    nextIndex,
+    completedItems
+  );
+}

--- a/packages/runtime/src/reveal-round.ts
+++ b/packages/runtime/src/reveal-round.ts
@@ -185,8 +185,8 @@ export function judgeRevealRoundInput(
       feedbackTitle: state.attemptCount > 1 ? "Nice recovery" : "Nice hit",
       feedbackBody:
         state.attemptCount > 1
-          ? `${state.termLabel} starts with ${state.expectedKey.toUpperCase()}. You cleared it after a supported repeat. Press Enter to replay the demo item.`
-          : `${state.termLabel} starts with ${state.expectedKey.toUpperCase()}. Press Enter to replay the demo item.`,
+          ? `${state.termLabel} starts with ${state.expectedKey.toUpperCase()}. You cleared it after a supported repeat. Press Enter to continue.`
+          : `${state.termLabel} starts with ${state.expectedKey.toUpperCase()}. Press Enter to continue.`,
       lastInput: normalizedKey
     };
   }

--- a/packages/runtime/src/scenes/BootScene.ts
+++ b/packages/runtime/src/scenes/BootScene.ts
@@ -1,24 +1,25 @@
 import Phaser from "phaser";
 import { createBootSceneModel } from "../demo-content";
 import {
-  advanceRevealRound,
-  beginRevealRound,
-  createRevealRoundState,
-  judgeRevealRoundInput,
-  restartRevealRound,
-  type RevealRoundState
-} from "../reveal-round";
+  advanceLearnStageRound,
+  beginLearnStageRound,
+  continueLearnStage,
+  createLearnStageState,
+  judgeLearnStageInput,
+  restartLearnStageRound,
+  type LearnStageState
+} from "../learn-stage";
 
 const PANEL_FILL = 0x1d2638;
 const CARD_FILL = 0x24324a;
-const IMAGE_KEY = "demo-item-image";
-const AUDIO_KEY = "demo-item-audio";
 const SUCCESS_COLOR = "#7ef0ad";
 const FAILURE_COLOR = "#ff8b7c";
 const NEUTRAL_COLOR = "#ffcf88";
 
 export class BootScene extends Phaser.Scene {
-  private roundState!: RevealRoundState;
+  private stageState!: LearnStageState;
+  private imageFrame!: Phaser.GameObjects.Image;
+  private subheadText!: Phaser.GameObjects.Text;
   private feedbackTitleText!: Phaser.GameObjects.Text;
   private feedbackBodyText!: Phaser.GameObjects.Text;
   private cueLabelText!: Phaser.GameObjects.Text;
@@ -32,14 +33,21 @@ export class BootScene extends Phaser.Scene {
   preload() {
     const model = createBootSceneModel();
 
-    this.load.image(IMAGE_KEY, model.imageSrc);
-    this.load.audio(AUDIO_KEY, [model.audioSrc]);
+    model.items.forEach((item, index) => {
+      this.load.image(this.getImageKey(index), item.imageSrc);
+      this.load.audio(this.getAudioKey(index), [item.audioSrc]);
+    });
   }
 
   create() {
     const { width, height } = this.scale;
     const model = createBootSceneModel();
-    const roundSetup = createRevealRoundState(model.item);
+
+    this.stageState = createLearnStageState({
+      packId: model.packId,
+      stageId: model.stageId,
+      items: model.items
+    });
 
     this.cameras.main.setBackgroundColor("#111927");
 
@@ -53,7 +61,7 @@ export class BootScene extends Phaser.Scene {
       })
       .setOrigin(0.5);
 
-    this.add
+    this.subheadText = this.add
       .text(width / 2, 96, model.subhead, {
         color: "#ffcf88",
         fontFamily: "Trebuchet MS, Verdana, sans-serif",
@@ -62,10 +70,10 @@ export class BootScene extends Phaser.Scene {
       .setOrigin(0.5);
 
     this.add.rectangle(width / 2, 260, 280, 280, CARD_FILL, 1).setStrokeStyle(2, 0xffcf88, 0.18);
-    this.add.image(width / 2, 260, IMAGE_KEY).setDisplaySize(220, 220);
+    this.imageFrame = this.add.image(width / 2, 260, this.getImageKey(0)).setDisplaySize(220, 220);
 
     this.cueLabelText = this.add
-      .text(width / 2, 420, `Visible cue: ${model.meaning}`, {
+      .text(width / 2, 420, "", {
         color: "#f6efe5",
         fontFamily: "Trebuchet MS, Verdana, sans-serif",
         fontSize: "26px",
@@ -110,72 +118,120 @@ export class BootScene extends Phaser.Scene {
       .setOrigin(0.5)
       .setVisible(false);
 
-    if (!roundSetup.ok) {
-      this.answerHintText.setText("This item needs a Latin-letter term before keyboard play can start.");
-      this.feedbackTitleText.setText("Content error");
-      this.feedbackTitleText.setColor(FAILURE_COLOR);
-      this.feedbackBodyText.setText(roundSetup.error.message);
-      return;
-    }
-
-    this.roundState = roundSetup.state;
-
     this.input.keyboard?.on("keydown", this.handleKeyDown, this);
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
       this.input.keyboard?.off("keydown", this.handleKeyDown, this);
     });
 
-    this.renderRoundState();
+    this.renderStageState();
   }
 
   private handleKeyDown = (event: KeyboardEvent) => {
     const normalizedKey = event.key.toLowerCase();
 
     if (normalizedKey === "enter") {
-      if (
-        this.roundState.phase === "idle" ||
-        this.roundState.phase === "retry-needed" ||
-        this.roundState.phase === "passed"
-      ) {
-        const idleState =
-          this.roundState.phase === "idle" ? this.roundState : restartRevealRound(this.roundState);
-
-        const attentionCueState = beginRevealRound(idleState);
-
-        this.roundState = attentionCueState;
-        this.renderRoundState();
-        this.roundState = advanceRevealRound(this.roundState);
-        this.renderRoundState();
-        this.roundState = advanceRevealRound(this.roundState);
-        this.renderRoundState();
-        this.playPronunciationCue();
-        this.roundState = advanceRevealRound(this.roundState);
-        this.renderRoundState();
-        this.roundState = advanceRevealRound(this.roundState);
-        this.renderRoundState();
+      if (this.stageState.kind !== "in-progress") {
+        return;
       }
 
+      if (this.stageState.roundState.phase === "passed") {
+        this.stageState = continueLearnStage(this.stageState);
+        this.renderStageState();
+        return;
+      }
+
+      const readyState =
+        this.stageState.roundState.phase === "idle"
+          ? this.stageState
+          : this.stageState.roundState.phase === "retry-needed"
+            ? restartLearnStageRound(this.stageState)
+            : this.stageState;
+
+      this.stageState = beginLearnStageRound(readyState);
+      this.renderRoundState();
+      this.stageState = advanceLearnStageRound(this.stageState);
+      this.renderRoundState();
+      this.stageState = advanceLearnStageRound(this.stageState);
+      this.renderRoundState();
+      this.playPronunciationCue();
+      this.stageState = advanceLearnStageRound(this.stageState);
+      this.renderRoundState();
+      this.stageState = advanceLearnStageRound(this.stageState);
+      this.renderRoundState();
       return;
     }
 
-    const nextState = judgeRevealRoundInput(this.roundState, event.key);
+    const nextState = judgeLearnStageInput(this.stageState, event.key);
 
-    if (nextState !== this.roundState) {
-      this.roundState = nextState;
+    if (nextState !== this.stageState) {
+      this.stageState = nextState;
       this.renderRoundState();
     }
   };
 
   private playPronunciationCue() {
+    if (this.stageState.kind !== "in-progress") {
+      return;
+    }
+
     this.sound.stopAll();
-    this.sound.play(AUDIO_KEY);
+    this.sound.play(this.getAudioKey(this.stageState.currentIndex));
+  }
+
+  private renderStageState() {
+    if (this.stageState.kind === "content-error") {
+      this.imageFrame.setVisible(false);
+      this.cueLabelText.setText("Visible cue unavailable");
+      this.answerHintText.setText("This item needs a Latin-letter term before keyboard play can start.");
+      this.feedbackTitleText.setText("Content error");
+      this.feedbackTitleText.setColor(FAILURE_COLOR);
+      this.feedbackBodyText.setText(this.stageState.error.message);
+      this.outcomeWordText.setVisible(false);
+      return;
+    }
+
+    if (this.stageState.kind === "summary") {
+      const supportedCount = this.stageState.completedItems.filter(
+        (item) => item.passedWithSupport
+      ).length;
+
+      this.imageFrame.setVisible(false);
+      this.subheadText.setText(
+        `Pack ${this.stageState.packId} / Stage ${this.stageState.stageId} / Summary`
+      );
+      this.cueLabelText.setText("Stage complete");
+      this.answerHintText.setText("Every scheduled Learn Mode item has been cleared.");
+      this.feedbackTitleText.setText("Stage summary");
+      this.feedbackTitleText.setColor(SUCCESS_COLOR);
+      this.feedbackBodyText.setText(
+        `Cleared ${this.stageState.completedItems.length} of ${this.stageState.totalItemCount} items. Supported repeats: ${supportedCount}.`
+      );
+      this.outcomeWordText
+        .setText(this.stageState.completedItems.map((item) => item.itemId).join("  •  "))
+        .setVisible(true);
+      return;
+    }
+
+    this.imageFrame
+      .setTexture(this.getImageKey(this.stageState.currentIndex))
+      .setVisible(true);
+    this.subheadText.setText(
+      `Pack ${this.stageState.packId} / Stage ${this.stageState.stageId} / Item ${this.stageState.currentIndex + 1} of ${this.stageState.items.length}`
+    );
+    this.cueLabelText.setText(`Visible cue: ${this.stageState.currentItem.item.meaning}`);
+    this.renderRoundState();
   }
 
   private renderRoundState() {
-    this.feedbackTitleText.setText(this.roundState.feedbackTitle);
-    this.feedbackBodyText.setText(this.roundState.feedbackBody);
+    if (this.stageState.kind !== "in-progress") {
+      return;
+    }
 
-    switch (this.roundState.phase) {
+    const { roundState } = this.stageState;
+    this.feedbackTitleText.setText(roundState.feedbackTitle);
+    this.feedbackBodyText.setText(roundState.feedbackBody);
+
+    switch (roundState.phase) {
       case "idle":
         this.feedbackTitleText.setColor(NEUTRAL_COLOR);
         this.outcomeWordText.setVisible(false);
@@ -195,27 +251,35 @@ export class BootScene extends Phaser.Scene {
       case "text-reveal":
         this.feedbackTitleText.setColor(NEUTRAL_COLOR);
         this.outcomeWordText.setVisible(true);
-        this.outcomeWordText.setText(`${this.roundState.termLabel} (${this.roundState.meaningLabel})`);
+        this.outcomeWordText.setText(`${roundState.termLabel} (${roundState.meaningLabel})`);
         break;
       case "awaiting-input":
         this.feedbackTitleText.setColor(NEUTRAL_COLOR);
-        this.outcomeWordText.setText(`${this.roundState.termLabel} (${this.roundState.meaningLabel})`);
+        this.outcomeWordText.setText(`${roundState.termLabel} (${roundState.meaningLabel})`);
         this.outcomeWordText.setVisible(true);
         break;
       case "retry-needed":
         this.feedbackTitleText.setColor(FAILURE_COLOR);
         this.outcomeWordText
-          .setText(`${this.roundState.termLabel} (${this.roundState.meaningLabel})`)
+          .setText(`${roundState.termLabel} (${roundState.meaningLabel})`)
           .setVisible(true);
         break;
       case "passed":
         this.feedbackTitleText.setColor(
-          this.roundState.judgment === "success" ? SUCCESS_COLOR : FAILURE_COLOR
+          roundState.judgment === "success" ? SUCCESS_COLOR : FAILURE_COLOR
         );
         this.outcomeWordText
-          .setText(`${this.roundState.termLabel} (${this.roundState.meaningLabel})`)
+          .setText(`${roundState.termLabel} (${roundState.meaningLabel})`)
           .setVisible(true);
         break;
     }
+  }
+
+  private getImageKey(index: number): string {
+    return `demo-item-image-${index}`;
+  }
+
+  private getAudioKey(index: number): string {
+    return `demo-item-audio-${index}`;
   }
 }


### PR DESCRIPTION
## What changed
- extend the runtime content seam from a single demo item to an ordered stage with multiple items
- add Learn Mode stage state management so the runtime can advance item-by-item and end in a summary state
- update the boot scene to drive multi-item Learn Mode progression, including continue and retry flow
- add and update tests for stage loading and Learn Mode stage behavior

## Why
Issue #125 needs Learn Mode to operate as a short stage instead of a single isolated demo loop. The preserved worktree already contained the stage-loading and progression implementation, and this publish flow packages that rescued work into a reviewable PR.

## Impact
- Learn Mode can move across multiple scheduled vocabulary items through the existing browser runtime
- retry/pass behavior now feeds stage progression instead of replaying a single item forever
- the runtime export surface now includes the Learn Mode stage helpers needed by the scene layer

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @fne/web build`

Closes #125


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced stage-based learning progression enabling sequential item-by-item mastery tracking
  * Added learning stage summary view displaying total items completed and per-item attempt counts
  * Implemented content error state handling with user-friendly error messaging

* **Tests**
  * Added comprehensive test coverage for stage state transitions and item progression workflows

* **Chores**
  * Updated user feedback text for improved clarity during learning rounds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->