### PR TITLE
Epic 13.3 - Implement forgiving response judgment and supportive repeat behavior (#126)

### DIFF
--- a/apps/web/src/learnStage.test.ts
+++ b/apps/web/src/learnStage.test.ts
@@ -4,6 +4,7 @@ import {
   continueLearnStage,
   createLearnStageState,
   judgeLearnStageInput,
+  judgeLearnStageTimeout,
   restartLearnStageRound,
   type LearnStageProgressState
 } from "@fne/runtime/learn-stage";
@@ -176,6 +177,43 @@ describe("learn stage state", () => {
         itemId: "banana",
         passedWithSupport: false,
         attemptCount: 1
+      }
+    ]);
+  });
+
+  it("keeps the same item active after a missed timing window and records the supported clear", () => {
+    const stage = expectInProgressState(createLearnStageState(createFixtureStage()));
+    const awaitingInput = moveToAwaitingInput(stage);
+    const missed = judgeLearnStageTimeout(awaitingInput);
+
+    expect(missed.kind).toBe("in-progress");
+
+    if (missed.kind !== "in-progress") {
+      throw new Error("expected an in-progress learn stage");
+    }
+
+    expect(missed.currentIndex).toBe(0);
+    expect(missed.currentItem.item.id).toBe("apple");
+    expect(missed.roundState.phase).toBe("retry-needed");
+    expect(missed.roundState.feedbackBody).toContain("little late");
+
+    const replayIdle = restartLearnStageRound(missed);
+    const replayAwaitingInput = moveToAwaitingInput(expectInProgressState(replayIdle));
+    const passed = judgeLearnStageInput(replayAwaitingInput, "a");
+    const nextItem = continueLearnStage(expectInProgressState(passed));
+
+    expect(nextItem.kind).toBe("in-progress");
+
+    if (nextItem.kind !== "in-progress") {
+      throw new Error("expected an in-progress learn stage");
+    }
+
+    expect(nextItem.currentIndex).toBe(1);
+    expect(nextItem.completedItems).toEqual([
+      {
+        itemId: "apple",
+        passedWithSupport: true,
+        attemptCount: 2
       }
     ]);
   });

--- a/apps/web/src/revealRound.test.ts
+++ b/apps/web/src/revealRound.test.ts
@@ -3,6 +3,7 @@ import {
   beginRevealRound,
   createRevealRoundState,
   judgeRevealRoundInput,
+  judgeRevealRoundTimeout,
   restartRevealRound,
   type RevealRoundState
 } from "@fne/runtime/reveal-round";
@@ -128,6 +129,45 @@ describe("reveal round state", () => {
     expect(advanceRevealRound(passed)).toBe(passed);
     expect(judgeRevealRoundInput(passed, "a")).toBe(passed);
     expect(beginRevealRound(passed)).toBe(passed);
+  });
+
+  it("marks a missed response as retry-needed and preserves the supportive repeat path", () => {
+    const state = expectPlayableState(
+      createRevealRoundState({
+        id: "apple",
+        term: "apple",
+        meaning: "りんご",
+        pronunciation: "AP-uhl",
+        imageAssetId: "img-apple",
+        audioAssetId: "aud-apple"
+      })
+    );
+
+    const awaitingInput = advanceRevealRound(
+      advanceRevealRound(advanceRevealRound(advanceRevealRound(beginRevealRound(state))))
+    );
+
+    expect(awaitingInput.phase).toBe("awaiting-input");
+
+    const missed = judgeRevealRoundTimeout(awaitingInput);
+
+    expect(missed.phase).toBe("retry-needed");
+    expect(missed.judgment).toBe("retry-needed");
+    expect(missed.lastInput).toBeNull();
+    expect(missed.feedbackTitle).toBe("Try again");
+    expect(missed.feedbackBody).toContain("little late");
+
+    const replayAwaitingInput = advanceRevealRound(
+      advanceRevealRound(
+        advanceRevealRound(
+          advanceRevealRound(beginRevealRound(restartRevealRound(missed)))
+        )
+      )
+    );
+    const recovered = judgeRevealRoundInput(replayAwaitingInput, "a");
+
+    expect(recovered.phase).toBe("passed");
+    expect(recovered.passedWithSupport).toBe(true);
   });
 
   it("returns a recoverable content error when the term has no Latin letter", () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -27,6 +27,7 @@ export {
   continueLearnStage,
   createLearnStageState,
   judgeLearnStageInput,
+  judgeLearnStageTimeout,
   restartLearnStageRound,
   type LearnStageContentErrorState,
   type LearnStageItemResult,
@@ -34,6 +35,19 @@ export {
   type LearnStageState,
   type LearnStageSummaryState
 } from "./learn-stage";
+export {
+  advanceRevealRound,
+  beginRevealRound,
+  createRevealRoundState,
+  judgeRevealRoundInput,
+  judgeRevealRoundTimeout,
+  restartRevealRound,
+  type RevealRoundContentError,
+  type RevealRoundJudgment,
+  type RevealRoundPhase,
+  type RevealRoundSetupResult,
+  type RevealRoundState
+} from "./reveal-round";
 export {
   createRuntimeGameConfig,
   mountRuntimeWithGameCtor,

--- a/packages/runtime/src/learn-stage.ts
+++ b/packages/runtime/src/learn-stage.ts
@@ -4,6 +4,7 @@ import {
   beginRevealRound,
   createRevealRoundState,
   judgeRevealRoundInput,
+  judgeRevealRoundTimeout,
   restartRevealRound,
   type RevealRoundContentError,
   type RevealRoundState
@@ -139,6 +140,17 @@ export function restartLearnStageRound(state: LearnStageState): LearnStageState 
   return {
     ...state,
     roundState: restartRevealRound(state.roundState)
+  };
+}
+
+export function judgeLearnStageTimeout(state: LearnStageState): LearnStageState {
+  if (state.kind !== "in-progress") {
+    return state;
+  }
+
+  return {
+    ...state,
+    roundState: judgeRevealRoundTimeout(state.roundState)
   };
 }
 

--- a/packages/runtime/src/reveal-round.ts
+++ b/packages/runtime/src/reveal-round.ts
@@ -201,6 +201,21 @@ export function judgeRevealRoundInput(
   };
 }
 
+export function judgeRevealRoundTimeout(state: RevealRoundState): RevealRoundState {
+  if (state.phase !== "awaiting-input") {
+    return state;
+  }
+
+  return {
+    ...state,
+    phase: "retry-needed",
+    judgment: "retry-needed",
+    feedbackTitle: "Try again",
+    feedbackBody: `A little late that time. ${state.termLabel} starts with ${state.expectedKey.toUpperCase()}. Press Enter to try again with the guided reveal and one more pronunciation cue.`,
+    lastInput: null
+  };
+}
+
 export function restartRevealRound(state: RevealRoundState): RevealRoundState {
   if (state.phase !== "retry-needed" && state.phase !== "passed") {
     return state;

--- a/packages/runtime/src/scenes/BootScene.ts
+++ b/packages/runtime/src/scenes/BootScene.ts
@@ -6,6 +6,7 @@ import {
   continueLearnStage,
   createLearnStageState,
   judgeLearnStageInput,
+  judgeLearnStageTimeout,
   restartLearnStageRound,
   type LearnStageState
 } from "../learn-stage";
@@ -15,9 +16,11 @@ const CARD_FILL = 0x24324a;
 const SUCCESS_COLOR = "#7ef0ad";
 const FAILURE_COLOR = "#ff8b7c";
 const NEUTRAL_COLOR = "#ffcf88";
+const LEARN_RESPONSE_WINDOW_MS = 1800;
 
 export class BootScene extends Phaser.Scene {
   private stageState!: LearnStageState;
+  private responseTimeoutEvent: Phaser.Time.TimerEvent | null = null;
   private imageFrame!: Phaser.GameObjects.Image;
   private subheadText!: Phaser.GameObjects.Text;
   private feedbackTitleText!: Phaser.GameObjects.Text;
@@ -120,6 +123,7 @@ export class BootScene extends Phaser.Scene {
 
     this.input.keyboard?.on("keydown", this.handleKeyDown, this);
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      this.clearResponseTimeout();
       this.input.keyboard?.off("keydown", this.handleKeyDown, this);
     });
 
@@ -135,6 +139,7 @@ export class BootScene extends Phaser.Scene {
       }
 
       if (this.stageState.roundState.phase === "passed") {
+        this.clearResponseTimeout();
         this.stageState = continueLearnStage(this.stageState);
         this.renderStageState();
         return;
@@ -158,16 +163,46 @@ export class BootScene extends Phaser.Scene {
       this.renderRoundState();
       this.stageState = advanceLearnStageRound(this.stageState);
       this.renderRoundState();
+      this.syncResponseTimeout();
       return;
     }
 
     const nextState = judgeLearnStageInput(this.stageState, event.key);
 
     if (nextState !== this.stageState) {
+      this.clearResponseTimeout();
       this.stageState = nextState;
       this.renderRoundState();
     }
   };
+
+  private syncResponseTimeout() {
+    this.clearResponseTimeout();
+
+    if (
+      this.stageState.kind !== "in-progress" ||
+      this.stageState.roundState.phase !== "awaiting-input"
+    ) {
+      return;
+    }
+
+    this.responseTimeoutEvent = this.time.delayedCall(LEARN_RESPONSE_WINDOW_MS, () => {
+      const nextState = judgeLearnStageTimeout(this.stageState);
+
+      if (nextState === this.stageState) {
+        return;
+      }
+
+      this.stageState = nextState;
+      this.responseTimeoutEvent = null;
+      this.renderRoundState();
+    });
+  }
+
+  private clearResponseTimeout() {
+    this.responseTimeoutEvent?.remove(false);
+    this.responseTimeoutEvent = null;
+  }
 
   private playPronunciationCue() {
     if (this.stageState.kind !== "in-progress") {


### PR DESCRIPTION
Closes #126
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the Learn Mode missed-response path as a narrow runtime change. The authoritative gap was that `awaiting-input` only handled explicit key presses, so no-input learners never transitioned into a supportive retry. The fix adds timeout-based judgment in the reveal-round and learn-stage state machines, then wires `BootScene` to trigger that timeout after a forgiving `1800ms` response window.

I also added focused regressions for the miss path and supported-repeat recovery, and committed the checkpoint as `78262a5` (`Add Learn Mode missed-response retry path`). `typecheck`, `lint`, and the targeted web tests passed. The issue journal’s Codex Working Notes were updated in the local supervisor artifacts; the remaining untracked files are supervisor metadata only.

Summary: Added a forgiving missed-response timeout path for Learn Mode, preserved the same-item supportive repeat flow, verified with focused tests plus typecheck and lint, and committed the checkpoint as `78262a5`.
State hint: implementing
Blocked reason: none
Tests: `pnpm --filter @fne/web test -- src/revealRound.test.ts src/learnStage.test.ts` (plus the package’s full web test run output), `pnpm typecheck`, `pnpm lint`
Failure signature: none
Next action: Open or update a draft PR for `codex/issue-126`, then do a quick manual browser pass to tune the `1800ms` response window if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented timeout management for interactive learning phases. When users don't respond within the designated response window during input stages, they receive feedback and can restart their attempt.

* **Chores**
  * Extended runtime API exports to include new timeout handling functions and reveal-round management utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->