### PR TITLE
Epic 13.4 - Add visible feedback and end-of-stage summary for Learn Mode (#127)

### DIFF
--- a/apps/web/src/learnStage.test.ts
+++ b/apps/web/src/learnStage.test.ts
@@ -5,6 +5,7 @@ import {
   createLearnStageState,
   judgeLearnStageInput,
   judgeLearnStageTimeout,
+  restartLearnStage,
   restartLearnStageRound,
   type LearnStageProgressState
 } from "@fne/runtime/learn-stage";
@@ -179,6 +180,38 @@ describe("learn stage state", () => {
         attemptCount: 1
       }
     ]);
+  });
+
+  it("restarts from the summary with the first item active again", () => {
+    let state = createLearnStageState(createFixtureStage());
+
+    for (const expectedKey of ["a", "m", "b"]) {
+      const awaitingInput = moveToAwaitingInput(expectInProgressState(state));
+      const passed = judgeLearnStageInput(awaitingInput, expectedKey);
+
+      expect(passed.kind).toBe("in-progress");
+
+      if (passed.kind !== "in-progress") {
+        throw new Error("expected an in-progress learn stage");
+      }
+
+      state = continueLearnStage(passed);
+    }
+
+    expect(state.kind).toBe("summary");
+
+    const restarted = restartLearnStage(state);
+
+    expect(restarted.kind).toBe("in-progress");
+
+    if (restarted.kind !== "in-progress") {
+      throw new Error("expected an in-progress learn stage");
+    }
+
+    expect(restarted.currentIndex).toBe(0);
+    expect(restarted.currentItem.item.id).toBe("apple");
+    expect(restarted.completedItems).toEqual([]);
+    expect(restarted.roundState.phase).toBe("idle");
   });
 
   it("keeps the same item active after a missed timing window and records the supported clear", () => {

--- a/apps/web/src/learnStage.test.ts
+++ b/apps/web/src/learnStage.test.ts
@@ -249,6 +249,16 @@ describe("learn stage state", () => {
     expect(restarted.roundState.audioCueRequestCount).toBe(1);
   });
 
+  it("does not advance an in-progress stage when replay is called outside the summary", () => {
+    const state = expectInProgressState(createLearnStageState(createFixtureStage()));
+    const replayed = restartLearnStageAndBeginRound(state);
+    const replayedInProgress = expectInProgressState(replayed);
+
+    expect(replayed).toBe(state);
+    expect(replayedInProgress.roundState.phase).toBe("idle");
+    expect(replayedInProgress.currentIndex).toBe(0);
+  });
+
   it("keeps the same item active after a missed timing window and records the supported clear", () => {
     const stage = expectInProgressState(createLearnStageState(createFixtureStage()));
     const awaitingInput = moveToAwaitingInput(stage);

--- a/apps/web/src/learnStage.test.ts
+++ b/apps/web/src/learnStage.test.ts
@@ -6,6 +6,7 @@ import {
   judgeLearnStageInput,
   judgeLearnStageTimeout,
   restartLearnStage,
+  restartLearnStageAndBeginRound,
   restartLearnStageRound,
   type LearnStageProgressState
 } from "@fne/runtime/learn-stage";
@@ -212,6 +213,40 @@ describe("learn stage state", () => {
     expect(restarted.currentItem.item.id).toBe("apple");
     expect(restarted.completedItems).toEqual([]);
     expect(restarted.roundState.phase).toBe("idle");
+  });
+
+  it("starts the first round immediately when the summary is replayed", () => {
+    let state = createLearnStageState(createFixtureStage());
+
+    for (const expectedKey of ["a", "m", "b"]) {
+      const awaitingInput = moveToAwaitingInput(expectInProgressState(state));
+      const passed = judgeLearnStageInput(awaitingInput, expectedKey);
+
+      expect(passed.kind).toBe("in-progress");
+
+      if (passed.kind !== "in-progress") {
+        throw new Error("expected an in-progress learn stage");
+      }
+
+      state = continueLearnStage(passed);
+    }
+
+    expect(state.kind).toBe("summary");
+
+    const restarted = restartLearnStageAndBeginRound(state);
+
+    expect(restarted.kind).toBe("in-progress");
+
+    if (restarted.kind !== "in-progress") {
+      throw new Error("expected an in-progress learn stage");
+    }
+
+    expect(restarted.currentIndex).toBe(0);
+    expect(restarted.currentItem.item.id).toBe("apple");
+    expect(restarted.completedItems).toEqual([]);
+    expect(restarted.roundState.phase).toBe("awaiting-input");
+    expect(restarted.roundState.attemptCount).toBe(1);
+    expect(restarted.roundState.audioCueRequestCount).toBe(1);
   });
 
   it("keeps the same item active after a missed timing window and records the supported clear", () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -28,6 +28,7 @@ export {
   createLearnStageState,
   judgeLearnStageInput,
   judgeLearnStageTimeout,
+  restartLearnStage,
   restartLearnStageRound,
   type LearnStageContentErrorState,
   type LearnStageItemResult,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -29,6 +29,7 @@ export {
   judgeLearnStageInput,
   judgeLearnStageTimeout,
   restartLearnStage,
+  restartLearnStageAndBeginRound,
   restartLearnStageRound,
   type LearnStageContentErrorState,
   type LearnStageItemResult,

--- a/packages/runtime/src/learn-stage.ts
+++ b/packages/runtime/src/learn-stage.ts
@@ -192,6 +192,10 @@ export function restartLearnStage(state: LearnStageState): LearnStageState {
 }
 
 export function restartLearnStageAndBeginRound(state: LearnStageState): LearnStageState {
+  if (state.kind !== "summary") {
+    return state;
+  }
+
   const restartedState = restartLearnStage(state);
 
   if (restartedState.kind !== "in-progress") {

--- a/packages/runtime/src/learn-stage.ts
+++ b/packages/runtime/src/learn-stage.ts
@@ -31,6 +31,7 @@ export interface LearnStageSummaryState {
   kind: "summary";
   packId: string;
   stageId: string;
+  items: RuntimeDemoItem[];
   completedItems: LearnStageItemResult[];
   totalItemCount: number;
 }
@@ -67,6 +68,7 @@ function createProgressState(
       kind: "summary",
       packId: stage.packId,
       stageId: stage.stageId,
+      items: stage.items,
       completedItems,
       totalItemCount: stage.items.length
     };
@@ -170,5 +172,21 @@ export function continueLearnStage(state: LearnStageState): LearnStageState {
     },
     nextIndex,
     completedItems
+  );
+}
+
+export function restartLearnStage(state: LearnStageState): LearnStageState {
+  if (state.kind !== "summary") {
+    return state;
+  }
+
+  return createProgressState(
+    {
+      packId: state.packId,
+      stageId: state.stageId,
+      items: state.items
+    },
+    0,
+    []
   );
 }

--- a/packages/runtime/src/learn-stage.ts
+++ b/packages/runtime/src/learn-stage.ts
@@ -190,3 +190,18 @@ export function restartLearnStage(state: LearnStageState): LearnStageState {
     []
   );
 }
+
+export function restartLearnStageAndBeginRound(state: LearnStageState): LearnStageState {
+  const restartedState = restartLearnStage(state);
+
+  if (restartedState.kind !== "in-progress") {
+    return restartedState;
+  }
+
+  const attentionCue = beginLearnStageRound(restartedState);
+  const imageReveal = advanceLearnStageRound(attentionCue);
+  const pronunciationReveal = advanceLearnStageRound(imageReveal);
+  const textReveal = advanceLearnStageRound(pronunciationReveal);
+
+  return advanceLearnStageRound(textReveal);
+}

--- a/packages/runtime/src/scenes/BootScene.ts
+++ b/packages/runtime/src/scenes/BootScene.ts
@@ -7,6 +7,7 @@ import {
   createLearnStageState,
   judgeLearnStageInput,
   judgeLearnStageTimeout,
+  restartLearnStage,
   restartLearnStageRound,
   type LearnStageState
 } from "../learn-stage";
@@ -134,6 +135,13 @@ export class BootScene extends Phaser.Scene {
     const normalizedKey = event.key.toLowerCase();
 
     if (normalizedKey === "enter") {
+      if (this.stageState.kind === "summary") {
+        this.clearResponseTimeout();
+        this.stageState = restartLearnStage(this.stageState);
+        this.renderStageState();
+        return;
+      }
+
       if (this.stageState.kind !== "in-progress") {
         return;
       }
@@ -229,21 +237,22 @@ export class BootScene extends Phaser.Scene {
       const supportedCount = this.stageState.completedItems.filter(
         (item) => item.passedWithSupport
       ).length;
+      const cleanClearCount = this.stageState.completedItems.length - supportedCount;
 
       this.imageFrame.setVisible(false);
       this.subheadText.setText(
         `Pack ${this.stageState.packId} / Stage ${this.stageState.stageId} / Summary`
       );
       this.cueLabelText.setText("Stage complete");
-      this.answerHintText.setText("Every scheduled Learn Mode item has been cleared.");
+      this.answerHintText.setText("Press Enter to play this stage again.");
       this.feedbackTitleText.setText("Stage summary");
       this.feedbackTitleText.setColor(SUCCESS_COLOR);
       this.feedbackBodyText.setText(
-        `Cleared ${this.stageState.completedItems.length} of ${this.stageState.totalItemCount} items. Supported repeats: ${supportedCount}.`
+        supportedCount === 0
+          ? `All ${this.stageState.totalItemCount} items cleared on the first try.`
+          : `First-try clears: ${cleanClearCount}. Needed another try: ${supportedCount}.`
       );
-      this.outcomeWordText
-        .setText(this.stageState.completedItems.map((item) => item.itemId).join("  •  "))
-        .setVisible(true);
+      this.outcomeWordText.setVisible(false);
       return;
     }
 

--- a/packages/runtime/src/scenes/BootScene.ts
+++ b/packages/runtime/src/scenes/BootScene.ts
@@ -7,7 +7,7 @@ import {
   createLearnStageState,
   judgeLearnStageInput,
   judgeLearnStageTimeout,
-  restartLearnStage,
+  restartLearnStageAndBeginRound,
   restartLearnStageRound,
   type LearnStageState
 } from "../learn-stage";
@@ -137,8 +137,11 @@ export class BootScene extends Phaser.Scene {
     if (normalizedKey === "enter") {
       if (this.stageState.kind === "summary") {
         this.clearResponseTimeout();
-        this.stageState = restartLearnStage(this.stageState);
+        this.stageState = restartLearnStageAndBeginRound(this.stageState);
         this.renderStageState();
+        this.renderRoundState();
+        this.playPronunciationCue();
+        this.syncResponseTimeout();
         return;
       }
 
@@ -263,6 +266,7 @@ export class BootScene extends Phaser.Scene {
       `Pack ${this.stageState.packId} / Stage ${this.stageState.stageId} / Item ${this.stageState.currentIndex + 1} of ${this.stageState.items.length}`
     );
     this.cueLabelText.setText(`Visible cue: ${this.stageState.currentItem.item.meaning}`);
+    this.answerHintText.setText("Listen for the English word, then type its first letter.");
     this.renderRoundState();
   }
 


### PR DESCRIPTION
Closes #127
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented and committed the Learn Mode summary fix in `aaf62b2` (`Add learn mode summary restart flow`).

The scoped change does three things: it adds a focused regression test proving summary restart was missing, makes summary state restartable through a new `restartLearnStage()` boundary, and updates the Phaser summary surface so it stays low-clutter and clearly tells the learner to press Enter to replay the stage. The raw item-id recap is gone; the summary now reports first-try clears vs items that needed another try.

Verification passed with `pnpm --filter @fne/web test -- src/learnStage.test.ts`, `pnpm typecheck`, and `pnpm lint`. I also updated the issue journal’s Codex Working Notes before finishing. The only remaining untracked files are supervisor artifacts under `.codex-supervisor/`.

Summary: Added a tested Learn Mode summary restart flow and simplified the end-of-stage recap so the next learner action is explicit.
State hint: implementing
Blocked reason: none
Tests: `pnpm --filter @fne/web test -- src/learnStage.test.ts`; `pnpm typecheck`; `pnpm lint`
Failure signature: none
Next action: review whether this branch should open a draft PR now or continue with a quick browser playthrough for manual UX confirmation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Press Enter on the summary screen to restart and replay the learn stage from the first item, automatically beginning the next round with audio cues.

* **UI/UX Improvements**
  * Updated summary messaging to guide replay and clarified first-try vs. additional-attempt statistics.
  * Removed the per-item outcome list; simplified answer hint to "Listen… then type its first letter."
  * Restarting while already in-progress now leaves the stage unchanged.

* **Tests**
  * Added automated tests verifying restart, replay, and no-op behavior when already in-progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->