### PR TITLE
Add Learn Mode validation path and notes

### DIFF
--- a/.codex-supervisor/issues/128/issue-journal.md
+++ b/.codex-supervisor/issues/128/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #128: Epic 13.5 - Add Learn Mode validation path and implementation notes
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/FNE/issues/128
+- Branch: codex/issue-128
+- Workspace: .
+- Journal: .codex-supervisor/issues/128/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 87c1eb0c687d9c9b39658f4a2e7f896f4e323563
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-19T01:50:24.807Z
+
+## Latest Codex Summary
+- None yet.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The Learn Mode slice already had contract coverage, but the repo exposed no dedicated validation entrypoint or reviewer-facing notes, so the repeatable local verification path was missing.
+- What changed: Added `scripts/smoke-learn-mode.sh` and wired it to `pnpm run smoke:learn-mode`; documented the Learn Mode verification path in `README.md` and `docs/learn-mode.md`.
+- Current blocker: none
+- Next exact step: Commit the Learn Mode validation-path changes on `codex/issue-128`, then decide whether to open the draft PR for this checkpoint.
+- Verification gap: none for the scoped acceptance checks; `pnpm run smoke:learn-mode`, `pnpm run smoke:runtime`, `pnpm run typecheck`, and `pnpm run lint` all passed after `pnpm install`.
+- Files touched: `scripts/smoke-learn-mode.sh`, `package.json`, `README.md`, `docs/learn-mode.md`
+- Rollback concern: Low; changes only add a validation wrapper script and documentation, with no runtime logic changes.
+- Last focused command: `pnpm run smoke:learn-mode`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The lint and typecheck gate expectations live in [docs/validation-gates.md](docs
 ## Local Validation
 Install dependencies with `pnpm install`, then use the repo validation scripts directly:
 
+- `pnpm run smoke:learn-mode` verifies the Learn Mode doc contract plus the stage-level reveal, retry, and summary progression path.
 - `pnpm run smoke:runtime` verifies the runtime skeleton still boots the Phaser shell and tears down cleanly.
 - `pnpm run typecheck` runs the TypeScript gate.
 - `pnpm run lint` runs the lint gate.

--- a/docs/learn-mode.md
+++ b/docs/learn-mode.md
@@ -78,3 +78,10 @@ Define the first-exposure learner flow for Learn Mode so implementation can sequ
 - Learn Mode defines reveal order, cue timing intent, feedback posture, and pass conditions.
 - Learn Mode does not define pack-specific word order, art style, scoring formulas, or unlock rules.
 - If a later issue needs stricter timing tiers or adaptive repetition counts, that work should extend this mode spec rather than replacing the image-first first-exposure flow.
+
+## Local Verification
+
+- Run `pnpm run smoke:learn-mode` after `pnpm install` to verify the Learn Mode slice stays aligned with this contract and with the implemented stage flow.
+- That smoke path should prove the reveal order, retry-needed recovery path, supported-repeat weak-word flag, and stage-summary progression without expanding into broader gameplay coverage.
+- Run `pnpm run smoke:runtime` alongside the Learn Mode smoke when you need to confirm the browser runtime still mounts cleanly after slice changes.
+- Run `pnpm run typecheck` and `pnpm run lint` before review so the slice stays aligned with the repo-wide validation gates.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "lint": "pnpm exec eslint apps packages --ext .ts,.tsx",
+    "smoke:learn-mode": "sh ./scripts/smoke-learn-mode.sh",
     "smoke:runtime": "pnpm --filter @fne/web test -- src/runtimeSmoke.test.ts",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm --filter @fne/web test"

--- a/scripts/smoke-learn-mode.sh
+++ b/scripts/smoke-learn-mode.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
+
+printf 'Running Learn Mode doc contract check...\n'
+"$script_dir/check-learn-mode.sh"
+
+printf 'Running Learn Mode runtime contract tests...\n'
+cd "$repo_root"
+pnpm --filter @fne/web test -- src/revealRound.test.ts src/learnStage.test.ts


### PR DESCRIPTION
## Summary
- add a repo-level `smoke:learn-mode` command for the Learn Mode slice
- document the local Learn Mode verification path in the README and Learn Mode spec
- keep validation aligned with the existing `typecheck` and `lint` gates

## Verification
- pnpm run smoke:learn-mode
- pnpm run smoke:runtime
- pnpm run typecheck
- pnpm run lint

Closes #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Learn Mode documentation with Local Verification section detailing validation steps and test commands.
  * Updated README with new Learn Mode validation command.

* **Tests**
  * Added automated Learn Mode validation script.
  * New `pnpm run smoke:learn-mode` command available for verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->