### PR TITLE
Implement battle mode timing and judgment pipeline

### DIFF
--- a/apps/web/src/battleStage.test.ts
+++ b/apps/web/src/battleStage.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  advanceBattleStageState,
   createBattleStageDefinition,
-  getBattleStageSnapshot
+  createBattleStageState,
+  getBattleStageSnapshot,
+  judgeBattleStageInput
 } from "@fne/runtime/battle-stage";
 import { loadDemoRuntimeStage } from "@fne/runtime/demo-content";
 
@@ -65,5 +68,97 @@ describe("battle stage baseline", () => {
     expect(earlyNote?.y).toBeLessThan(midNote?.y ?? Number.POSITIVE_INFINITY);
     expect(midNote?.y).toBeLessThan(hitNote?.y ?? Number.POSITIVE_INFINITY);
     expect(hitNote?.y).toBeCloseTo(hitNote?.receptorY ?? -1, 1);
+  });
+
+  it("registers a hit when the matching lane key lands inside the timing window", () => {
+    const battleStage = createBattleStageDefinition(loadDemoRuntimeStage());
+    const note = battleStage.notes[0];
+
+    expect(note).toBeDefined();
+
+    if (note === undefined) {
+      throw new Error("expected the battle stage to schedule at least one note");
+    }
+
+    const lane = battleStage.lanes[note.laneIndex];
+    const initialState = createBattleStageState(battleStage);
+    const judgedState = judgeBattleStageInput(
+      initialState,
+      note.hitTimeMs + 36,
+      lane.key
+    );
+
+    expect(judgedState.noteStates[note.id]).toBe("hit");
+    expect(judgedState.lastJudgment).toMatchObject({
+      noteId: note.id,
+      laneIndex: note.laneIndex,
+      outcome: "hit",
+      inputKey: lane.key,
+      offsetMs: 36,
+      consumedNote: true
+    });
+
+    const snapshotAfterHit = getBattleStageSnapshot(
+      battleStage,
+      note.hitTimeMs + 36,
+      judgedState
+    );
+    const hitNote = snapshotAfterHit.notes.find((candidate) => candidate.id === note.id);
+
+    expect(hitNote?.isVisible).toBe(false);
+  });
+
+  it("keeps failed inputs separate from the durable miss that closes the note window", () => {
+    const battleStage = createBattleStageDefinition(loadDemoRuntimeStage());
+    const note = battleStage.notes[0];
+
+    expect(note).toBeDefined();
+
+    if (note === undefined) {
+      throw new Error("expected the battle stage to schedule at least one note");
+    }
+
+    const wrongLane = battleStage.lanes[(note.laneIndex + 1) % battleStage.lanes.length];
+    const matchingLane = battleStage.lanes[note.laneIndex];
+    const initialState = createBattleStageState(battleStage);
+    const wrongLaneAttempt = judgeBattleStageInput(
+      initialState,
+      note.hitTimeMs,
+      wrongLane.key
+    );
+
+    expect(wrongLaneAttempt.noteStates[note.id]).toBe("pending");
+    expect(wrongLaneAttempt.lastJudgment).toMatchObject({
+      noteId: note.id,
+      laneIndex: note.laneIndex,
+      inputKey: wrongLane.key,
+      outcome: "wrong-lane",
+      consumedNote: false
+    });
+
+    const tooEarlyAttempt = judgeBattleStageInput(
+      wrongLaneAttempt,
+      note.hitTimeMs - 220,
+      matchingLane.key
+    );
+
+    expect(tooEarlyAttempt.noteStates[note.id]).toBe("pending");
+    expect(tooEarlyAttempt.lastJudgment).toMatchObject({
+      noteId: note.id,
+      laneIndex: note.laneIndex,
+      inputKey: matchingLane.key,
+      outcome: "too-early",
+      consumedNote: false
+    });
+
+    const settledState = advanceBattleStageState(tooEarlyAttempt, note.hitTimeMs + 181);
+
+    expect(settledState.noteStates[note.id]).toBe("missed");
+    expect(settledState.lastJudgment).toMatchObject({
+      noteId: note.id,
+      laneIndex: note.laneIndex,
+      outcome: "missed-window",
+      consumedNote: true
+    });
   });
 });

--- a/apps/web/src/battleStage.test.ts
+++ b/apps/web/src/battleStage.test.ts
@@ -161,4 +161,62 @@ describe("battle stage baseline", () => {
       consumedNote: true
     });
   });
+
+  it("resets note state when elapsed time skips across a full chart loop", () => {
+    const battleStage = createBattleStageDefinition(loadDemoRuntimeStage());
+    const note = battleStage.notes[0];
+
+    expect(note).toBeDefined();
+
+    if (note === undefined) {
+      throw new Error("expected the battle stage to schedule at least one note");
+    }
+
+    const lane = battleStage.lanes[note.laneIndex];
+    const initialState = createBattleStageState(battleStage);
+    const hitState = judgeBattleStageInput(
+      initialState,
+      note.hitTimeMs + 36,
+      lane.key
+    );
+    const loopedState = advanceBattleStageState(
+      hitState,
+      battleStage.totalDurationMs + note.hitTimeMs + 60
+    );
+
+    expect(loopedState.loopCount).toBe(1);
+    expect(loopedState.noteStates[note.id]).toBe("pending");
+    expect(loopedState.lastJudgment).toBeNull();
+  });
+
+  it("judges a late keypress against the missed note instead of the next pending note", () => {
+    const battleStage = createBattleStageDefinition(loadDemoRuntimeStage());
+    const firstNote = battleStage.notes[0];
+    const nextNote = battleStage.notes[1];
+
+    expect(firstNote).toBeDefined();
+    expect(nextNote).toBeDefined();
+
+    if (firstNote === undefined || nextNote === undefined) {
+      throw new Error("expected the battle stage to schedule at least two notes");
+    }
+
+    const lane = battleStage.lanes[firstNote.laneIndex];
+    const initialState = createBattleStageState(battleStage);
+    const lateState = judgeBattleStageInput(
+      initialState,
+      firstNote.hitTimeMs + 181,
+      lane.key
+    );
+
+    expect(lateState.noteStates[firstNote.id]).toBe("missed");
+    expect(lateState.noteStates[nextNote.id]).toBe("pending");
+    expect(lateState.lastJudgment).toMatchObject({
+      noteId: firstNote.id,
+      laneIndex: firstNote.laneIndex,
+      inputKey: lane.key,
+      outcome: "missed-window",
+      consumedNote: true
+    });
+  });
 });

--- a/packages/runtime/src/battle-stage.ts
+++ b/packages/runtime/src/battle-stage.ts
@@ -154,20 +154,34 @@ function createInitialNoteStates(battleStage: BattleStageDefinition): Record<str
   );
 }
 
+function getNextLoopCount(battleStage: BattleStageDefinition, elapsedTimeMs: number): number {
+  return battleStage.totalDurationMs > 0
+    ? Math.max(0, Math.floor(elapsedTimeMs / battleStage.totalDurationMs))
+    : 0;
+}
+
+function getFirstPendingNote(
+  battleStage: BattleStageDefinition,
+  noteStates: Record<string, BattleNoteState>
+): BattleNoteDefinition | undefined {
+  return battleStage.notes.find((note) => noteStates[note.id] === "pending");
+}
+
 function syncBattleLoop(
   state: BattleStageState,
   battleStage: BattleStageDefinition,
   elapsedTimeMs: number
 ): BattleStageState {
   const timelineTimeMs = getTimelineTimeMs(battleStage, elapsedTimeMs);
+  const nextLoopCount = getNextLoopCount(battleStage, elapsedTimeMs);
 
-  if (timelineTimeMs < state.timelineTimeMs) {
+  if (nextLoopCount !== state.loopCount) {
     return {
       battleStage,
       noteStates: createInitialNoteStates(battleStage),
       lastJudgment: null,
       timelineTimeMs,
-      loopCount: state.loopCount + 1
+      loopCount: nextLoopCount
     };
   }
 
@@ -236,8 +250,9 @@ export function judgeBattleStageInput(
   key: string
 ): BattleStageState {
   const { battleStage } = state;
-  const advancedState = advanceBattleStageState(state, elapsedTimeMs);
-  const targetNote = battleStage.notes.find((note) => advancedState.noteStates[note.id] === "pending");
+  const loopSyncedState = syncBattleLoop(state, battleStage, elapsedTimeMs);
+  const targetNote = getFirstPendingNote(battleStage, loopSyncedState.noteStates);
+  const advancedState = advanceBattleStageState(loopSyncedState, elapsedTimeMs);
 
   if (targetNote === undefined) {
     return advancedState;
@@ -249,7 +264,24 @@ export function judgeBattleStageInput(
     return advancedState;
   }
 
-  const offsetMs = advancedState.timelineTimeMs - targetNote.hitTimeMs;
+  const offsetMs = loopSyncedState.timelineTimeMs - targetNote.hitTimeMs;
+
+  if (offsetMs > HIT_WINDOW_MS) {
+    return {
+      ...advancedState,
+      lastJudgment: {
+        noteId: targetNote.id,
+        itemId: targetNote.itemId,
+        laneIndex: targetNote.laneIndex,
+        inputKey: key,
+        inputLaneIndex,
+        judgedAtMs: loopSyncedState.timelineTimeMs,
+        offsetMs,
+        outcome: "missed-window",
+        consumedNote: true
+      }
+    };
+  }
 
   if (offsetMs < -HIT_WINDOW_MS) {
     return {
@@ -260,7 +292,7 @@ export function judgeBattleStageInput(
         laneIndex: targetNote.laneIndex,
         inputKey: key,
         inputLaneIndex,
-        judgedAtMs: advancedState.timelineTimeMs,
+        judgedAtMs: loopSyncedState.timelineTimeMs,
         offsetMs,
         outcome: "too-early",
         consumedNote: false
@@ -277,7 +309,7 @@ export function judgeBattleStageInput(
         laneIndex: targetNote.laneIndex,
         inputKey: key,
         inputLaneIndex,
-        judgedAtMs: advancedState.timelineTimeMs,
+        judgedAtMs: loopSyncedState.timelineTimeMs,
         offsetMs,
         outcome: "wrong-lane",
         consumedNote: false
@@ -297,7 +329,7 @@ export function judgeBattleStageInput(
       laneIndex: targetNote.laneIndex,
       inputKey: key,
       inputLaneIndex,
-      judgedAtMs: advancedState.timelineTimeMs,
+      judgedAtMs: loopSyncedState.timelineTimeMs,
       offsetMs,
       outcome: "hit",
       consumedNote: true

--- a/packages/runtime/src/battle-stage.ts
+++ b/packages/runtime/src/battle-stage.ts
@@ -19,6 +19,7 @@ const NOTE_SPAWN_TOP_PX = PLAYFIELD_TOP_PX + 112;
 const DEFAULT_BPM = 100;
 const PREVIEW_RECOVERY_MS = 900;
 const NOTE_TRAVEL_MS = 2200;
+const HIT_WINDOW_MS = 180;
 
 export type BattleLaneDirection = (typeof BATTLE_LANE_DIRECTIONS)[number];
 
@@ -81,6 +82,29 @@ export interface BattleStageSnapshot {
   notes: BattleNoteSnapshot[];
 }
 
+export type BattleNoteState = "pending" | "hit" | "missed";
+export type BattleJudgmentOutcome = "hit" | "wrong-lane" | "too-early" | "missed-window";
+
+export interface BattleJudgmentEvent {
+  noteId: string;
+  itemId: string;
+  laneIndex: number;
+  inputKey: string | null;
+  inputLaneIndex: number | null;
+  judgedAtMs: number;
+  offsetMs: number;
+  outcome: BattleJudgmentOutcome;
+  consumedNote: boolean;
+}
+
+export interface BattleStageState {
+  battleStage: BattleStageDefinition;
+  noteStates: Record<string, BattleNoteState>;
+  lastJudgment: BattleJudgmentEvent | null;
+  timelineTimeMs: number;
+  loopCount: number;
+}
+
 function createBounds(left: number, top: number, width: number, height: number): BattleBounds {
   return {
     left,
@@ -115,6 +139,170 @@ function createLanePattern(noteCount: number, anchorLaneIndex: number): number[]
   ] as const;
 
   return [...stablePatterns[noteCount - 1]];
+}
+
+function getTimelineTimeMs(battleStage: BattleStageDefinition, elapsedTimeMs: number): number {
+  return battleStage.totalDurationMs > 0
+    ? ((elapsedTimeMs % battleStage.totalDurationMs) + battleStage.totalDurationMs) %
+        battleStage.totalDurationMs
+    : 0;
+}
+
+function createInitialNoteStates(battleStage: BattleStageDefinition): Record<string, BattleNoteState> {
+  return Object.fromEntries(
+    battleStage.notes.map((note) => [note.id, "pending"] satisfies [string, BattleNoteState])
+  );
+}
+
+function syncBattleLoop(
+  state: BattleStageState,
+  battleStage: BattleStageDefinition,
+  elapsedTimeMs: number
+): BattleStageState {
+  const timelineTimeMs = getTimelineTimeMs(battleStage, elapsedTimeMs);
+
+  if (timelineTimeMs < state.timelineTimeMs) {
+    return {
+      battleStage,
+      noteStates: createInitialNoteStates(battleStage),
+      lastJudgment: null,
+      timelineTimeMs,
+      loopCount: state.loopCount + 1
+    };
+  }
+
+  if (timelineTimeMs === state.timelineTimeMs) {
+    return state;
+  }
+
+  return {
+    ...state,
+    timelineTimeMs
+  };
+}
+
+export function createBattleStageState(battleStage: BattleStageDefinition): BattleStageState {
+  return {
+    battleStage,
+    noteStates: createInitialNoteStates(battleStage),
+    lastJudgment: null,
+    timelineTimeMs: 0,
+    loopCount: 0
+  };
+}
+
+export function advanceBattleStageState(state: BattleStageState, elapsedTimeMs: number): BattleStageState {
+  const { battleStage } = state;
+  const loopSyncedState = syncBattleLoop(state, battleStage, elapsedTimeMs);
+  let nextState = loopSyncedState;
+
+  for (const note of battleStage.notes) {
+    if (nextState.noteStates[note.id] !== "pending") {
+      continue;
+    }
+
+    const missDeadlineMs = note.hitTimeMs + HIT_WINDOW_MS;
+
+    if (nextState.timelineTimeMs <= missDeadlineMs) {
+      break;
+    }
+
+    nextState = {
+      ...nextState,
+      noteStates: {
+        ...nextState.noteStates,
+        [note.id]: "missed"
+      },
+      lastJudgment: {
+        noteId: note.id,
+        itemId: note.itemId,
+        laneIndex: note.laneIndex,
+        inputKey: null,
+        inputLaneIndex: null,
+        judgedAtMs: nextState.timelineTimeMs,
+        offsetMs: nextState.timelineTimeMs - note.hitTimeMs,
+        outcome: "missed-window",
+        consumedNote: true
+      }
+    };
+  }
+
+  return nextState;
+}
+
+export function judgeBattleStageInput(
+  state: BattleStageState,
+  elapsedTimeMs: number,
+  key: string
+): BattleStageState {
+  const { battleStage } = state;
+  const advancedState = advanceBattleStageState(state, elapsedTimeMs);
+  const targetNote = battleStage.notes.find((note) => advancedState.noteStates[note.id] === "pending");
+
+  if (targetNote === undefined) {
+    return advancedState;
+  }
+
+  const inputLaneIndex = battleStage.lanes.findIndex((lane) => lane.key === key);
+
+  if (inputLaneIndex === -1) {
+    return advancedState;
+  }
+
+  const offsetMs = advancedState.timelineTimeMs - targetNote.hitTimeMs;
+
+  if (offsetMs < -HIT_WINDOW_MS) {
+    return {
+      ...advancedState,
+      lastJudgment: {
+        noteId: targetNote.id,
+        itemId: targetNote.itemId,
+        laneIndex: targetNote.laneIndex,
+        inputKey: key,
+        inputLaneIndex,
+        judgedAtMs: advancedState.timelineTimeMs,
+        offsetMs,
+        outcome: "too-early",
+        consumedNote: false
+      }
+    };
+  }
+
+  if (inputLaneIndex !== targetNote.laneIndex) {
+    return {
+      ...advancedState,
+      lastJudgment: {
+        noteId: targetNote.id,
+        itemId: targetNote.itemId,
+        laneIndex: targetNote.laneIndex,
+        inputKey: key,
+        inputLaneIndex,
+        judgedAtMs: advancedState.timelineTimeMs,
+        offsetMs,
+        outcome: "wrong-lane",
+        consumedNote: false
+      }
+    };
+  }
+
+  return {
+    ...advancedState,
+    noteStates: {
+      ...advancedState.noteStates,
+      [targetNote.id]: "hit"
+    },
+    lastJudgment: {
+      noteId: targetNote.id,
+      itemId: targetNote.itemId,
+      laneIndex: targetNote.laneIndex,
+      inputKey: key,
+      inputLaneIndex,
+      judgedAtMs: advancedState.timelineTimeMs,
+      offsetMs,
+      outcome: "hit",
+      consumedNote: true
+    }
+  };
 }
 
 export function createBattleStageDefinition(stage: RuntimeStage): BattleStageDefinition {
@@ -198,13 +386,10 @@ export function createBattleStageDefinition(stage: RuntimeStage): BattleStageDef
 
 export function getBattleStageSnapshot(
   battleStage: BattleStageDefinition,
-  elapsedTimeMs: number
+  elapsedTimeMs: number,
+  state?: BattleStageState
 ): BattleStageSnapshot {
-  const timelineTimeMs =
-    battleStage.totalDurationMs > 0
-      ? ((elapsedTimeMs % battleStage.totalDurationMs) + battleStage.totalDurationMs) %
-        battleStage.totalDurationMs
-      : 0;
+  const timelineTimeMs = getTimelineTimeMs(battleStage, elapsedTimeMs);
   const activePhrase =
     battleStage.phrases.find(
       (phrase) =>
@@ -217,8 +402,9 @@ export function getBattleStageSnapshot(
     const progress = Math.min(Math.max(rawProgress, 0), 1);
     const y = NOTE_SPAWN_TOP_PX + (lane.receptorY - NOTE_SPAWN_TOP_PX) * progress;
     const lingerMs = 180;
+    const isResolved = state !== undefined && state.noteStates[note.id] !== "pending";
     const isVisible =
-      timelineTimeMs >= note.spawnTimeMs && timelineTimeMs <= note.hitTimeMs + lingerMs;
+      !isResolved && timelineTimeMs >= note.spawnTimeMs && timelineTimeMs <= note.hitTimeMs + lingerMs;
 
     return {
       ...note,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -11,6 +11,22 @@ import {
 
 export { BootScene } from "./scenes/BootScene";
 export {
+  advanceBattleStageState,
+  createBattleStageDefinition,
+  createBattleStageState,
+  getBattleStageSnapshot,
+  judgeBattleStageInput,
+  type BattleJudgmentEvent,
+  type BattleJudgmentOutcome,
+  type BattleLaneDefinition,
+  type BattleNoteDefinition,
+  type BattleNoteSnapshot,
+  type BattleNoteState,
+  type BattleStageDefinition,
+  type BattleStageSnapshot,
+  type BattleStageState
+} from "./battle-stage";
+export {
   createBootSceneModel,
   loadDemoRuntimeStage,
   loadDemoRuntimeItem,

--- a/packages/runtime/src/scenes/BootScene.ts
+++ b/packages/runtime/src/scenes/BootScene.ts
@@ -1,8 +1,12 @@
 import Phaser from "phaser";
 import {
+  advanceBattleStageState,
   createBattleStageDefinition,
+  createBattleStageState,
   getBattleStageSnapshot,
-  type BattleStageDefinition
+  judgeBattleStageInput,
+  type BattleStageDefinition,
+  type BattleStageState
 } from "../battle-stage";
 import { loadDemoRuntimeStage, type RuntimeDemoItem, type RuntimeStage } from "../demo-content";
 
@@ -13,16 +17,24 @@ const NOTE_FILLS = [0xff8b7c, 0xffcf88, 0x7ef0ad, 0x83d7ff];
 const RECEPTOR_IDLE_FILL = 0xe6edf5;
 const RECEPTOR_ACTIVE_FILL = 0xffcf88;
 const INPUT_PULSE_MS = 140;
+const JUDGMENT_COLORS = {
+  hit: "#7ef0ad",
+  "wrong-lane": "#ff8b7c",
+  "too-early": "#83d7ff",
+  "missed-window": "#ff8b7c"
+} as const;
 
 export class BootScene extends Phaser.Scene {
   private runtimeStage!: RuntimeStage;
   private battleStage!: BattleStageDefinition;
+  private battleState!: BattleStageState;
   private sceneStartTimeMs = 0;
   private cueImageFrame!: Phaser.GameObjects.Image;
   private cueWordText!: Phaser.GameObjects.Text;
   private cueMeaningText!: Phaser.GameObjects.Text;
   private cuePronunciationText!: Phaser.GameObjects.Text;
   private inputLegendText!: Phaser.GameObjects.Text;
+  private judgmentText!: Phaser.GameObjects.Text;
   private receptorSprites: Phaser.GameObjects.Rectangle[] = [];
   private noteSprites = new Map<string, Phaser.GameObjects.Rectangle>();
   private activeItemId: string | null = null;
@@ -45,6 +57,7 @@ export class BootScene extends Phaser.Scene {
   create() {
     this.runtimeStage = loadDemoRuntimeStage();
     this.battleStage = createBattleStageDefinition(this.runtimeStage);
+    this.battleState = createBattleStageState(this.battleStage);
     this.itemsById = new Map(
       this.runtimeStage.items.map((item) => [item.item.id, item] satisfies [string, RuntimeDemoItem])
     );
@@ -128,6 +141,15 @@ export class BootScene extends Phaser.Scene {
         wordWrap: { width: cueArea.width - 32 }
       })
       .setOrigin(0.5);
+    this.judgmentText = this.add
+      .text(centerX, cueArea.bottom - 106, "Waiting for first note", {
+        color: "#d6dee8",
+        fontFamily: "Trebuchet MS, Verdana, sans-serif",
+        fontSize: "16px",
+        align: "center",
+        wordWrap: { width: cueArea.width - 32 }
+      })
+      .setOrigin(0.5);
   }
 
   private renderLanePlayfield() {
@@ -203,7 +225,9 @@ export class BootScene extends Phaser.Scene {
   }
 
   private refreshFrame(elapsedTimeMs: number) {
-    const snapshot = getBattleStageSnapshot(this.battleStage, elapsedTimeMs);
+    this.battleState = advanceBattleStageState(this.battleState, elapsedTimeMs);
+
+    const snapshot = getBattleStageSnapshot(this.battleStage, elapsedTimeMs, this.battleState);
 
     snapshot.notes.forEach((note) => {
       const sprite = this.noteSprites.get(note.id);
@@ -227,6 +251,8 @@ export class BootScene extends Phaser.Scene {
       this.activeItemId = snapshot.activeItemId;
       this.renderActiveCue(snapshot.activeItemId);
     }
+
+    this.renderJudgmentFeedback();
   }
 
   private renderActiveCue(activeItemId: string | null) {
@@ -255,7 +281,38 @@ export class BootScene extends Phaser.Scene {
     }
 
     this.lanePulseUntilMs[laneIndex] = this.time.now + INPUT_PULSE_MS;
+    this.battleState = judgeBattleStageInput(
+      this.battleState,
+      this.time.now - this.sceneStartTimeMs,
+      event.key
+    );
+    this.renderJudgmentFeedback();
   };
+
+  private renderJudgmentFeedback() {
+    const judgment = this.battleState.lastJudgment;
+
+    if (judgment === null) {
+      this.judgmentText.setColor("#d6dee8").setText("Waiting for first note");
+
+      return;
+    }
+
+    const labelByOutcome = {
+      hit: "Hit",
+      "wrong-lane": "Wrong lane",
+      "too-early": "Too early",
+      "missed-window": "Miss"
+    } as const;
+    const timingLabel =
+      judgment.outcome === "wrong-lane" || judgment.outcome === "missed-window"
+        ? ""
+        : ` (${judgment.offsetMs >= 0 ? "+" : ""}${judgment.offsetMs}ms)`;
+
+    this.judgmentText
+      .setColor(JUDGMENT_COLORS[judgment.outcome])
+      .setText(`${labelByOutcome[judgment.outcome]}${timingLabel}`);
+  }
 
   private getImageKey(index: number) {
     return `runtime-item-image-${index}`;


### PR DESCRIPTION
## Summary
- add a pure battle-stage state that tracks pending, hit, and missed notes across looped chart playback
- judge learner input against explicit timing windows with hit, wrong-lane, too-early, and missed-window outcomes
- wire the BootScene battle slice to the judgment pipeline and cover the behavior with focused tests

Part of #136
Depends on #137
Closes #138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added note hit detection and input judgment system to track player interactions and timing offsets.
  * Introduced on-screen judgment feedback showing outcome type, color, and timing offset.
  * Notes now automatically transition to missed when outside the hit window and loop behavior correctly advances timeline.

* **Tests**
  * Added comprehensive tests covering hits, missed windows, wrong/early inputs, loop advancement, and judgment state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->