### PR TITLE
Epic 14.3 - Implement frame-level hit feel baseline (#139)

### DIFF
--- a/apps/web/src/battleStage.test.ts
+++ b/apps/web/src/battleStage.test.ts
@@ -97,6 +97,13 @@ describe("battle stage baseline", () => {
       offsetMs: 36,
       consumedNote: true
     });
+    expect(judgedState.hitFeedback).toMatchObject({
+      laneIndex: note.laneIndex,
+      startedAtMs: note.hitTimeMs + 36,
+      endsAtMs: note.hitTimeMs + 36 + 120,
+      judgmentOutcome: "hit",
+      confirmationLabel: "Hit (+36ms)"
+    });
 
     const snapshotAfterHit = getBattleStageSnapshot(
       battleStage,
@@ -106,6 +113,26 @@ describe("battle stage baseline", () => {
     const hitNote = snapshotAfterHit.notes.find((candidate) => candidate.id === note.id);
 
     expect(hitNote?.isVisible).toBe(false);
+  });
+
+  it("expires the hit feel baseline quickly so adjacent hits stay readable", () => {
+    const battleStage = createBattleStageDefinition(loadDemoRuntimeStage());
+    const note = battleStage.notes[0];
+
+    expect(note).toBeDefined();
+
+    if (note === undefined) {
+      throw new Error("expected the battle stage to schedule at least one note");
+    }
+
+    const lane = battleStage.lanes[note.laneIndex];
+    const hitState = judgeBattleStageInput(createBattleStageState(battleStage), note.hitTimeMs, lane.key);
+
+    expect(hitState.hitFeedback).not.toBeNull();
+
+    const settledState = advanceBattleStageState(hitState, note.hitTimeMs + 121);
+
+    expect(settledState.hitFeedback).toBeNull();
   });
 
   it("keeps failed inputs separate from the durable miss that closes the note window", () => {

--- a/packages/runtime/src/battle-stage.ts
+++ b/packages/runtime/src/battle-stage.ts
@@ -20,6 +20,7 @@ const DEFAULT_BPM = 100;
 const PREVIEW_RECOVERY_MS = 900;
 const NOTE_TRAVEL_MS = 2200;
 const HIT_WINDOW_MS = 180;
+const HIT_FEEL_DURATION_MS = 120;
 
 export type BattleLaneDirection = (typeof BATTLE_LANE_DIRECTIONS)[number];
 
@@ -97,10 +98,19 @@ export interface BattleJudgmentEvent {
   consumedNote: boolean;
 }
 
+export interface BattleHitFeedback {
+  laneIndex: number;
+  startedAtMs: number;
+  endsAtMs: number;
+  judgmentOutcome: "hit";
+  confirmationLabel: string;
+}
+
 export interface BattleStageState {
   battleStage: BattleStageDefinition;
   noteStates: Record<string, BattleNoteState>;
   lastJudgment: BattleJudgmentEvent | null;
+  hitFeedback: BattleHitFeedback | null;
   timelineTimeMs: number;
   loopCount: number;
 }
@@ -180,6 +190,7 @@ function syncBattleLoop(
       battleStage,
       noteStates: createInitialNoteStates(battleStage),
       lastJudgment: null,
+      hitFeedback: null,
       timelineTimeMs,
       loopCount: nextLoopCount
     };
@@ -191,7 +202,11 @@ function syncBattleLoop(
 
   return {
     ...state,
-    timelineTimeMs
+    timelineTimeMs,
+    hitFeedback:
+      state.hitFeedback !== null && timelineTimeMs > state.hitFeedback.endsAtMs
+        ? null
+        : state.hitFeedback
   };
 }
 
@@ -200,9 +215,14 @@ export function createBattleStageState(battleStage: BattleStageDefinition): Batt
     battleStage,
     noteStates: createInitialNoteStates(battleStage),
     lastJudgment: null,
+    hitFeedback: null,
     timelineTimeMs: 0,
     loopCount: 0
   };
+}
+
+function formatHitConfirmationLabel(offsetMs: number): string {
+  return `Hit (${offsetMs >= 0 ? "+" : ""}${offsetMs}ms)`;
 }
 
 export function advanceBattleStageState(state: BattleStageState, elapsedTimeMs: number): BattleStageState {
@@ -237,7 +257,8 @@ export function advanceBattleStageState(state: BattleStageState, elapsedTimeMs: 
         offsetMs: nextState.timelineTimeMs - note.hitTimeMs,
         outcome: "missed-window",
         consumedNote: true
-      }
+      },
+      hitFeedback: null
     };
   }
 
@@ -279,7 +300,8 @@ export function judgeBattleStageInput(
         offsetMs,
         outcome: "missed-window",
         consumedNote: true
-      }
+      },
+      hitFeedback: null
     };
   }
 
@@ -296,7 +318,8 @@ export function judgeBattleStageInput(
         offsetMs,
         outcome: "too-early",
         consumedNote: false
-      }
+      },
+      hitFeedback: null
     };
   }
 
@@ -313,7 +336,8 @@ export function judgeBattleStageInput(
         offsetMs,
         outcome: "wrong-lane",
         consumedNote: false
-      }
+      },
+      hitFeedback: null
     };
   }
 
@@ -333,6 +357,13 @@ export function judgeBattleStageInput(
       offsetMs,
       outcome: "hit",
       consumedNote: true
+    },
+    hitFeedback: {
+      laneIndex: targetNote.laneIndex,
+      startedAtMs: loopSyncedState.timelineTimeMs,
+      endsAtMs: loopSyncedState.timelineTimeMs + HIT_FEEL_DURATION_MS,
+      judgmentOutcome: "hit",
+      confirmationLabel: formatHitConfirmationLabel(offsetMs)
     }
   };
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -16,6 +16,7 @@ export {
   createBattleStageState,
   getBattleStageSnapshot,
   judgeBattleStageInput,
+  type BattleHitFeedback,
   type BattleJudgmentEvent,
   type BattleJudgmentOutcome,
   type BattleLaneDefinition,

--- a/packages/runtime/src/scenes/BootScene.ts
+++ b/packages/runtime/src/scenes/BootScene.ts
@@ -16,7 +16,6 @@ const LANE_FILLS = [0x233354, 0x26415d, 0x274766, 0x2c3c59];
 const NOTE_FILLS = [0xff8b7c, 0xffcf88, 0x7ef0ad, 0x83d7ff];
 const RECEPTOR_IDLE_FILL = 0xe6edf5;
 const RECEPTOR_ACTIVE_FILL = 0xffcf88;
-const INPUT_PULSE_MS = 140;
 const JUDGMENT_COLORS = {
   hit: "#7ef0ad",
   "wrong-lane": "#ff8b7c",
@@ -38,7 +37,6 @@ export class BootScene extends Phaser.Scene {
   private receptorSprites: Phaser.GameObjects.Rectangle[] = [];
   private noteSprites = new Map<string, Phaser.GameObjects.Rectangle>();
   private activeItemId: string | null = null;
-  private lanePulseUntilMs: number[] = [0, 0, 0, 0];
   private itemsById = new Map<string, RuntimeDemoItem>();
 
   constructor() {
@@ -240,18 +238,12 @@ export class BootScene extends Phaser.Scene {
       sprite.setAlpha(note.isVisible ? 0.96 : 0);
     });
 
-    this.receptorSprites.forEach((receptor, laneIndex) => {
-      const isActive = this.time.now <= this.lanePulseUntilMs[laneIndex];
-
-      receptor.setFillStyle(isActive ? RECEPTOR_ACTIVE_FILL : RECEPTOR_IDLE_FILL, 1);
-      receptor.setScale(1, isActive ? 1.18 : 1);
-    });
-
     if (snapshot.activeItemId !== this.activeItemId) {
       this.activeItemId = snapshot.activeItemId;
       this.renderActiveCue(snapshot.activeItemId);
     }
 
+    this.renderHitFeedback();
     this.renderJudgmentFeedback();
   }
 
@@ -280,19 +272,42 @@ export class BootScene extends Phaser.Scene {
       return;
     }
 
-    this.lanePulseUntilMs[laneIndex] = this.time.now + INPUT_PULSE_MS;
     this.battleState = judgeBattleStageInput(
       this.battleState,
       this.time.now - this.sceneStartTimeMs,
       event.key
     );
+    this.renderHitFeedback();
     this.renderJudgmentFeedback();
   };
 
+  private renderHitFeedback() {
+    const hitFeedback = this.battleState.hitFeedback;
+    const activeLaneIndex =
+      hitFeedback !== null && this.battleState.timelineTimeMs <= hitFeedback.endsAtMs
+        ? hitFeedback.laneIndex
+        : -1;
+
+    this.receptorSprites.forEach((receptor, laneIndex) => {
+      const isActive = laneIndex === activeLaneIndex;
+
+      receptor.setFillStyle(isActive ? RECEPTOR_ACTIVE_FILL : RECEPTOR_IDLE_FILL, 1);
+      receptor.setScale(1, isActive ? 1.18 : 1);
+    });
+  }
+
   private renderJudgmentFeedback() {
+    const hitFeedback = this.battleState.hitFeedback;
+
+    if (hitFeedback !== null && this.battleState.timelineTimeMs <= hitFeedback.endsAtMs) {
+      this.judgmentText.setColor(JUDGMENT_COLORS.hit).setText(hitFeedback.confirmationLabel);
+
+      return;
+    }
+
     const judgment = this.battleState.lastJudgment;
 
-    if (judgment === null) {
+    if (judgment === null || judgment.outcome === "hit") {
       this.judgmentText.setColor("#d6dee8").setText("Waiting for first note");
 
       return;


### PR DESCRIPTION
Closes #139
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the baseline judged-hit feel path in runtime and scene code. The fix adds a short-lived `hitFeedback` object to `BattleStageState`, emits it immediately on successful judged hits, expires it after 120ms, and has `BootScene` render receptor flash and hit confirmation directly from that runtime-backed event instead of the old local “pulse on any keydown” path. I also tightened the battle-stage tests to prove immediate hit-feedback emission and quick expiry for adjacent hits.

Local verification passed: `pnpm --filter @fne/web test -- src/battleStage.test.ts`, `pnpm test`, `pnpm typecheck`, and `pnpm lint`. Checkpoint commit: `1b462ba` (`Add runtime-backed battle hit feedback`). The issue journal was updated in the worktree and remains uncommitted under `.codex-supervisor/`.

Summary: Added runtime-backed judged-hit feedback with immediate receptor flash, short confirmation timing, focused regression coverage, and a checkpoint commit.
State hint: implementing
Blocked reason: none
Tests: `pnpm --filter @fne/web test -- src/battleStage.test.ts`; `pnpm test`; `pnpm typecheck`; `pnpm lint`
Failure signature: none
Next action: Manual live-play validation of hit feel timing, then open or update a draft PR if the browser pass feels correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual hit feedback that displays when you successfully hit notes, showing the precise timing offset of your input.
  * Enhanced receptor highlighting system to provide clearer and more immediate visual confirmation of successful note hits.
  * Hit feedback automatically expires after a brief duration to prevent visual overlap with subsequent notes and maintain clean gameplay visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->