### PR TITLE
Epic 14.4 - Implement combo, streak break, and visible excitement milestones (#141)

### DIFF
--- a/apps/web/src/battleStage.test.ts
+++ b/apps/web/src/battleStage.test.ts
@@ -246,4 +246,94 @@ describe("battle stage baseline", () => {
       consumedNote: true
     });
   });
+
+  it("tracks combo streaks, emits readable milestone accents, and clears the streak on failure", () => {
+    const battleStage = createBattleStageDefinition(loadDemoRuntimeStage());
+    const [firstNote, secondNote, thirdNote, fourthNote, fifthNote] = battleStage.notes;
+
+    expect(firstNote).toBeDefined();
+    expect(secondNote).toBeDefined();
+    expect(thirdNote).toBeDefined();
+    expect(fourthNote).toBeDefined();
+    expect(fifthNote).toBeDefined();
+
+    if (
+      firstNote === undefined ||
+      secondNote === undefined ||
+      thirdNote === undefined ||
+      fourthNote === undefined ||
+      fifthNote === undefined
+    ) {
+      throw new Error("expected the battle stage to schedule at least five notes");
+    }
+
+    const firstLane = battleStage.lanes[firstNote.laneIndex];
+    const secondLane = battleStage.lanes[secondNote.laneIndex];
+    const thirdLane = battleStage.lanes[thirdNote.laneIndex];
+    const fourthLane = battleStage.lanes[fourthNote.laneIndex];
+    const wrongFifthLane = battleStage.lanes[(fifthNote.laneIndex + 1) % battleStage.lanes.length];
+
+    const firstHit = judgeBattleStageInput(
+      createBattleStageState(battleStage),
+      firstNote.hitTimeMs,
+      firstLane.key
+    );
+
+    expect(firstHit.comboCount).toBe(1);
+    expect(firstHit.bestComboCount).toBe(1);
+    expect(firstHit.comboFeedback).toMatchObject({
+      comboCount: 1,
+      milestoneThreshold: null
+    });
+
+    const secondHit = judgeBattleStageInput(firstHit, secondNote.hitTimeMs, secondLane.key);
+
+    expect(secondHit.comboCount).toBe(2);
+    expect(secondHit.bestComboCount).toBe(2);
+    expect(secondHit.comboFeedback).toMatchObject({
+      comboCount: 2,
+      milestoneThreshold: null
+    });
+
+    const thirdHit = judgeBattleStageInput(secondHit, thirdNote.hitTimeMs, thirdLane.key);
+
+    expect(thirdHit.comboCount).toBe(3);
+    expect(thirdHit.bestComboCount).toBe(3);
+    expect(thirdHit.comboFeedback).toMatchObject({
+      comboCount: 3,
+      milestoneThreshold: 3
+    });
+    expect(thirdHit.comboFeedback?.endsAtMs).toBeGreaterThan(thirdNote.hitTimeMs);
+    const settledMilestone = advanceBattleStageState(
+      thirdHit,
+      (thirdHit.comboFeedback?.endsAtMs ?? thirdNote.hitTimeMs) + 1
+    );
+
+    expect(settledMilestone.comboCount).toBe(3);
+    expect(settledMilestone.comboFeedback).toBeNull();
+
+    const fourthHit = judgeBattleStageInput(settledMilestone, fourthNote.hitTimeMs, fourthLane.key);
+
+    expect(fourthHit.comboCount).toBe(4);
+    expect(fourthHit.bestComboCount).toBe(4);
+    expect(fourthHit.comboFeedback).toMatchObject({
+      comboCount: 4,
+      milestoneThreshold: null
+    });
+
+    const brokenCombo = judgeBattleStageInput(
+      fourthHit,
+      fifthNote.hitTimeMs,
+      wrongFifthLane.key
+    );
+
+    expect(brokenCombo.comboCount).toBe(0);
+    expect(brokenCombo.bestComboCount).toBe(4);
+    expect(brokenCombo.comboFeedback).toBeNull();
+    expect(brokenCombo.lastJudgment).toMatchObject({
+      noteId: fifthNote.id,
+      outcome: "wrong-lane",
+      consumedNote: false
+    });
+  });
 });

--- a/packages/runtime/src/battle-stage.ts
+++ b/packages/runtime/src/battle-stage.ts
@@ -21,6 +21,8 @@ const PREVIEW_RECOVERY_MS = 900;
 const NOTE_TRAVEL_MS = 2200;
 const HIT_WINDOW_MS = 180;
 const HIT_FEEL_DURATION_MS = 120;
+const COMBO_FEEL_DURATION_MS = 240;
+const COMBO_MILESTONE_THRESHOLDS = [3, 5, 10] as const;
 
 export type BattleLaneDirection = (typeof BATTLE_LANE_DIRECTIONS)[number];
 
@@ -106,11 +108,22 @@ export interface BattleHitFeedback {
   confirmationLabel: string;
 }
 
+export interface BattleComboFeedback {
+  comboCount: number;
+  milestoneThreshold: (typeof COMBO_MILESTONE_THRESHOLDS)[number] | null;
+  startedAtMs: number;
+  endsAtMs: number;
+  label: string;
+}
+
 export interface BattleStageState {
   battleStage: BattleStageDefinition;
   noteStates: Record<string, BattleNoteState>;
   lastJudgment: BattleJudgmentEvent | null;
   hitFeedback: BattleHitFeedback | null;
+  comboCount: number;
+  bestComboCount: number;
+  comboFeedback: BattleComboFeedback | null;
   timelineTimeMs: number;
   loopCount: number;
 }
@@ -191,6 +204,9 @@ function syncBattleLoop(
       noteStates: createInitialNoteStates(battleStage),
       lastJudgment: null,
       hitFeedback: null,
+      comboCount: 0,
+      bestComboCount: state.bestComboCount,
+      comboFeedback: null,
       timelineTimeMs,
       loopCount: nextLoopCount
     };
@@ -206,7 +222,11 @@ function syncBattleLoop(
     hitFeedback:
       state.hitFeedback !== null && timelineTimeMs > state.hitFeedback.endsAtMs
         ? null
-        : state.hitFeedback
+        : state.hitFeedback,
+    comboFeedback:
+      state.comboFeedback !== null && timelineTimeMs > state.comboFeedback.endsAtMs
+        ? null
+        : state.comboFeedback
   };
 }
 
@@ -216,6 +236,9 @@ export function createBattleStageState(battleStage: BattleStageDefinition): Batt
     noteStates: createInitialNoteStates(battleStage),
     lastJudgment: null,
     hitFeedback: null,
+    comboCount: 0,
+    bestComboCount: 0,
+    comboFeedback: null,
     timelineTimeMs: 0,
     loopCount: 0
   };
@@ -223,6 +246,27 @@ export function createBattleStageState(battleStage: BattleStageDefinition): Batt
 
 function formatHitConfirmationLabel(offsetMs: number): string {
   return `Hit (${offsetMs >= 0 ? "+" : ""}${offsetMs}ms)`;
+}
+
+function getComboMilestoneThreshold(comboCount: number) {
+  return COMBO_MILESTONE_THRESHOLDS.find((threshold) => threshold === comboCount) ?? null;
+}
+
+function formatComboLabel(comboCount: number, milestoneThreshold: number | null) {
+  return milestoneThreshold === null ? `${comboCount} combo` : `${comboCount} combo!`;
+}
+
+function breakCombo(
+  state: BattleStageState,
+  lastJudgment: BattleJudgmentEvent
+): BattleStageState {
+  return {
+    ...state,
+    lastJudgment,
+    hitFeedback: null,
+    comboCount: 0,
+    comboFeedback: null
+  };
 }
 
 export function advanceBattleStageState(state: BattleStageState, elapsedTimeMs: number): BattleStageState {
@@ -258,7 +302,9 @@ export function advanceBattleStageState(state: BattleStageState, elapsedTimeMs: 
         outcome: "missed-window",
         consumedNote: true
       },
-      hitFeedback: null
+      hitFeedback: null,
+      comboCount: 0,
+      comboFeedback: null
     };
   }
 
@@ -288,9 +334,7 @@ export function judgeBattleStageInput(
   const offsetMs = loopSyncedState.timelineTimeMs - targetNote.hitTimeMs;
 
   if (offsetMs > HIT_WINDOW_MS) {
-    return {
-      ...advancedState,
-      lastJudgment: {
+    return breakCombo(advancedState, {
         noteId: targetNote.id,
         itemId: targetNote.itemId,
         laneIndex: targetNote.laneIndex,
@@ -300,15 +344,11 @@ export function judgeBattleStageInput(
         offsetMs,
         outcome: "missed-window",
         consumedNote: true
-      },
-      hitFeedback: null
-    };
+      });
   }
 
   if (offsetMs < -HIT_WINDOW_MS) {
-    return {
-      ...advancedState,
-      lastJudgment: {
+    return breakCombo(advancedState, {
         noteId: targetNote.id,
         itemId: targetNote.itemId,
         laneIndex: targetNote.laneIndex,
@@ -318,15 +358,11 @@ export function judgeBattleStageInput(
         offsetMs,
         outcome: "too-early",
         consumedNote: false
-      },
-      hitFeedback: null
-    };
+      });
   }
 
   if (inputLaneIndex !== targetNote.laneIndex) {
-    return {
-      ...advancedState,
-      lastJudgment: {
+    return breakCombo(advancedState, {
         noteId: targetNote.id,
         itemId: targetNote.itemId,
         laneIndex: targetNote.laneIndex,
@@ -336,10 +372,11 @@ export function judgeBattleStageInput(
         offsetMs,
         outcome: "wrong-lane",
         consumedNote: false
-      },
-      hitFeedback: null
-    };
+      });
   }
+
+  const comboCount = advancedState.comboCount + 1;
+  const milestoneThreshold = getComboMilestoneThreshold(comboCount);
 
   return {
     ...advancedState,
@@ -364,6 +401,15 @@ export function judgeBattleStageInput(
       endsAtMs: loopSyncedState.timelineTimeMs + HIT_FEEL_DURATION_MS,
       judgmentOutcome: "hit",
       confirmationLabel: formatHitConfirmationLabel(offsetMs)
+    },
+    comboCount,
+    bestComboCount: Math.max(advancedState.bestComboCount, comboCount),
+    comboFeedback: {
+      comboCount,
+      milestoneThreshold,
+      startedAtMs: loopSyncedState.timelineTimeMs,
+      endsAtMs: loopSyncedState.timelineTimeMs + COMBO_FEEL_DURATION_MS,
+      label: formatComboLabel(comboCount, milestoneThreshold)
     }
   };
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -12,6 +12,7 @@ import {
 export { BootScene } from "./scenes/BootScene";
 export {
   advanceBattleStageState,
+  type BattleComboFeedback,
   createBattleStageDefinition,
   createBattleStageState,
   getBattleStageSnapshot,

--- a/packages/runtime/src/scenes/BootScene.ts
+++ b/packages/runtime/src/scenes/BootScene.ts
@@ -16,6 +16,9 @@ const LANE_FILLS = [0x233354, 0x26415d, 0x274766, 0x2c3c59];
 const NOTE_FILLS = [0xff8b7c, 0xffcf88, 0x7ef0ad, 0x83d7ff];
 const RECEPTOR_IDLE_FILL = 0xe6edf5;
 const RECEPTOR_ACTIVE_FILL = 0xffcf88;
+const COMBO_IDLE_COLOR = "#d6dee8";
+const COMBO_HIT_COLOR = "#f6efe5";
+const COMBO_MILESTONE_COLOR = "#ffcf88";
 const JUDGMENT_COLORS = {
   hit: "#7ef0ad",
   "wrong-lane": "#ff8b7c",
@@ -34,6 +37,7 @@ export class BootScene extends Phaser.Scene {
   private cuePronunciationText!: Phaser.GameObjects.Text;
   private inputLegendText!: Phaser.GameObjects.Text;
   private judgmentText!: Phaser.GameObjects.Text;
+  private comboText!: Phaser.GameObjects.Text;
   private receptorSprites: Phaser.GameObjects.Rectangle[] = [];
   private noteSprites = new Map<string, Phaser.GameObjects.Rectangle>();
   private activeItemId: string | null = null;
@@ -176,6 +180,15 @@ export class BootScene extends Phaser.Scene {
         fontFamily: "Trebuchet MS, Verdana, sans-serif",
         fontSize: "14px"
       });
+    this.comboText = this.add
+      .text(playfield.right - 20, playfield.top + 34, "Combo x0", {
+        color: COMBO_IDLE_COLOR,
+        fontFamily: "Trebuchet MS, Verdana, sans-serif",
+        fontSize: "18px",
+        fontStyle: "bold",
+        align: "right"
+      })
+      .setOrigin(1, 0.5);
 
     lanes.forEach((lane) => {
       this.add
@@ -245,6 +258,7 @@ export class BootScene extends Phaser.Scene {
 
     this.renderHitFeedback();
     this.renderJudgmentFeedback();
+    this.renderComboFeedback();
   }
 
   private renderActiveCue(activeItemId: string | null) {
@@ -279,6 +293,7 @@ export class BootScene extends Phaser.Scene {
     );
     this.renderHitFeedback();
     this.renderJudgmentFeedback();
+    this.renderComboFeedback();
   };
 
   private renderHitFeedback() {
@@ -327,6 +342,30 @@ export class BootScene extends Phaser.Scene {
     this.judgmentText
       .setColor(JUDGMENT_COLORS[judgment.outcome])
       .setText(`${labelByOutcome[judgment.outcome]}${timingLabel}`);
+  }
+
+  private renderComboFeedback() {
+    const { comboCount, comboFeedback, timelineTimeMs } = this.battleState;
+    const activeComboFeedback =
+      comboFeedback !== null && timelineTimeMs <= comboFeedback.endsAtMs ? comboFeedback : null;
+    const milestoneThreshold = activeComboFeedback?.milestoneThreshold ?? null;
+    const fontSize = milestoneThreshold === null ? "18px" : milestoneThreshold >= 10 ? "28px" : "24px";
+    const comboLabel =
+      comboCount > 0
+        ? activeComboFeedback?.label ?? `${comboCount} combo`
+        : "Combo x0";
+
+    this.comboText
+      .setText(comboLabel)
+      .setColor(
+        comboCount === 0
+          ? COMBO_IDLE_COLOR
+          : milestoneThreshold === null
+            ? COMBO_HIT_COLOR
+            : COMBO_MILESTONE_COLOR
+      )
+      .setFontSize(fontSize)
+      .setScale(1, 1);
   }
 
   private getImageKey(index: number) {


### PR DESCRIPTION
Closes #141
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the combo/streak slice on `codex/issue-141` and committed it as `bb839d8` (`Add battle combo streak feedback`).

The runtime now tracks `comboCount`, `bestComboCount`, and short-lived `comboFeedback` at the battle judgment boundary, so hits, streak breaks, and 3/5/10 milestone accents all come from the authoritative judged event instead of scene-only inference. `BootScene` now renders a compact combo HUD treatment that stays secondary to the lanes and cue panel, and the focused `battleStage` test now proves streak build, milestone emission, milestone expiry, and immediate break-on-failed-judgment behavior. I also updated the issue journal’s Codex Working Notes in the local supervisor journal; those supervisor files remain uncommitted.

Summary: Implemented battle combo tracking, streak breaks, milestone accents, and a visible combo HUD; added a focused regression and committed the code as `bb839d8`.
State hint: implementing
Blocked reason: none
Tests: `pnpm --filter @fne/web test -- src/battleStage.test.ts`; `pnpm typecheck`; `pnpm lint`; `pnpm test`
Failure signature: none
Next action: Open a draft PR for `codex/issue-141` from commit `bb839d8` and then do the manual feel/readability playtest for combo milestones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Combo tracking system with real-time on-screen counter during gameplay
- Visual milestone feedback appears at key combo thresholds with enhanced styling and emphasis
- Combo automatically resets on incorrect input while preserving best combo record
- Dynamic visual updates with color and size changes for milestone achievements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->