### PR TITLE
Epic 14.5: implement miss handling, fail meter, and instant retry flow

### DIFF
--- a/apps/web/src/battleStage.test.ts
+++ b/apps/web/src/battleStage.test.ts
@@ -4,7 +4,8 @@ import {
   createBattleStageDefinition,
   createBattleStageState,
   getBattleStageSnapshot,
-  judgeBattleStageInput
+  judgeBattleStageInput,
+  restartBattleStage
 } from "@fne/runtime/battle-stage";
 import { loadDemoRuntimeStage } from "@fne/runtime/demo-content";
 
@@ -335,5 +336,67 @@ describe("battle stage baseline", () => {
       outcome: "wrong-lane",
       consumedNote: false
     });
+  });
+
+  it("fails the stage after sustained missed windows and supports an instant retry reset", () => {
+    const battleStage = createBattleStageDefinition(loadDemoRuntimeStage());
+    const [firstNote, secondNote, thirdNote, fourthNote, fifthNote] = battleStage.notes;
+
+    expect(firstNote).toBeDefined();
+    expect(secondNote).toBeDefined();
+    expect(thirdNote).toBeDefined();
+    expect(fourthNote).toBeDefined();
+    expect(fifthNote).toBeDefined();
+
+    if (
+      firstNote === undefined ||
+      secondNote === undefined ||
+      thirdNote === undefined ||
+      fourthNote === undefined ||
+      fifthNote === undefined
+    ) {
+      throw new Error("expected the battle stage to schedule at least five notes");
+    }
+
+    const firstMiss = advanceBattleStageState(
+      createBattleStageState(battleStage),
+      firstNote.hitTimeMs + 181
+    );
+    const secondMiss = advanceBattleStageState(firstMiss, secondNote.hitTimeMs + 181);
+    const thirdMiss = advanceBattleStageState(secondMiss, thirdNote.hitTimeMs + 181);
+    const failedState = advanceBattleStageState(thirdMiss, fourthNote.hitTimeMs + 181);
+
+    expect(firstMiss.failMeter.value).toBeGreaterThan(failedState.failMeter.value);
+    expect(thirdMiss.stageStatus).toBe("playing");
+    expect(thirdMiss.noteStates[fifthNote.id]).toBe("pending");
+    expect(failedState.failMeter.value).toBe(0);
+    expect(failedState.stageStatus).toBe("failed");
+    expect(failedState.failedAtMs).toBe(fourthNote.hitTimeMs + 181);
+    expect(failedState.lastJudgment).toMatchObject({
+      noteId: fourthNote.id,
+      outcome: "missed-window",
+      consumedNote: true
+    });
+
+    const ignoredInput = judgeBattleStageInput(
+      failedState,
+      fifthNote.hitTimeMs,
+      battleStage.lanes[fifthNote.laneIndex].key
+    );
+
+    expect(ignoredInput).toBe(failedState);
+
+    const restarted = restartBattleStage(failedState);
+
+    expect(restarted.stageStatus).toBe("playing");
+    expect(restarted.failedAtMs).toBeNull();
+    expect(restarted.failMeter).toEqual({
+      value: 100,
+      maxValue: 100
+    });
+    expect(restarted.comboCount).toBe(0);
+    expect(restarted.lastJudgment).toBeNull();
+    expect(restarted.noteStates[firstNote.id]).toBe("pending");
+    expect(restarted.noteStates[fourthNote.id]).toBe("pending");
   });
 });

--- a/apps/web/src/battleStage.test.ts
+++ b/apps/web/src/battleStage.test.ts
@@ -399,4 +399,61 @@ describe("battle stage baseline", () => {
     expect(restarted.noteStates[firstNote.id]).toBe("pending");
     expect(restarted.noteStates[fourthNote.id]).toBe("pending");
   });
+
+  it("keeps playing snapshots live while preserving the failed-stage freeze", () => {
+    const battleStage = createBattleStageDefinition(loadDemoRuntimeStage());
+    const [firstNote, secondNote, thirdNote, fourthNote] = battleStage.notes;
+
+    expect(firstNote).toBeDefined();
+    expect(secondNote).toBeDefined();
+    expect(thirdNote).toBeDefined();
+    expect(fourthNote).toBeDefined();
+
+    if (
+      firstNote === undefined ||
+      secondNote === undefined ||
+      thirdNote === undefined ||
+      fourthNote === undefined
+    ) {
+      throw new Error("expected the battle stage to schedule at least four notes");
+    }
+
+    const stalePlayingState = createBattleStageState(battleStage);
+    const playingElapsedTimeMs = firstNote.spawnTimeMs + firstNote.travelDurationMs / 2;
+    const playingSnapshot = getBattleStageSnapshot(
+      battleStage,
+      playingElapsedTimeMs,
+      stalePlayingState
+    );
+    const expectedPlayingSnapshot = getBattleStageSnapshot(battleStage, playingElapsedTimeMs);
+    const playingNote = playingSnapshot.notes.find((candidate) => candidate.id === firstNote.id);
+    const expectedPlayingNote = expectedPlayingSnapshot.notes.find(
+      (candidate) => candidate.id === firstNote.id
+    );
+
+    expect(playingNote?.y).toBeCloseTo(expectedPlayingNote?.y ?? -1, 5);
+    expect(playingNote?.progress).toBeCloseTo(expectedPlayingNote?.progress ?? -1, 5);
+    expect(playingNote?.isVisible).toBe(expectedPlayingNote?.isVisible ?? false);
+
+    const firstMiss = advanceBattleStageState(
+      createBattleStageState(battleStage),
+      firstNote.hitTimeMs + 181
+    );
+    const secondMiss = advanceBattleStageState(firstMiss, secondNote.hitTimeMs + 181);
+    const thirdMiss = advanceBattleStageState(secondMiss, thirdNote.hitTimeMs + 181);
+    const failedState = advanceBattleStageState(thirdMiss, fourthNote.hitTimeMs + 181);
+    const failedSnapshot = getBattleStageSnapshot(
+      battleStage,
+      battleStage.totalDurationMs + firstNote.hitTimeMs,
+      failedState
+    );
+    const expectedFailedSnapshot = getBattleStageSnapshot(
+      battleStage,
+      failedState.timelineTimeMs,
+      failedState
+    );
+
+    expect(failedState.stageStatus).toBe("failed");
+    expect(failedSnapshot).toEqual(expectedFailedSnapshot);
+  });
 });

--- a/packages/runtime/src/battle-stage.ts
+++ b/packages/runtime/src/battle-stage.ts
@@ -23,6 +23,9 @@ const HIT_WINDOW_MS = 180;
 const HIT_FEEL_DURATION_MS = 120;
 const COMBO_FEEL_DURATION_MS = 240;
 const COMBO_MILESTONE_THRESHOLDS = [3, 5, 10] as const;
+const FAIL_METER_MAX_VALUE = 100;
+const FAIL_METER_DRAIN_PER_MISS = 25;
+const FAIL_METER_RECOVERY_PER_HIT = 8;
 
 export type BattleLaneDirection = (typeof BATTLE_LANE_DIRECTIONS)[number];
 
@@ -116,6 +119,13 @@ export interface BattleComboFeedback {
   label: string;
 }
 
+export interface BattleFailMeter {
+  value: number;
+  maxValue: number;
+}
+
+export type BattleStageStatus = "playing" | "failed";
+
 export interface BattleStageState {
   battleStage: BattleStageDefinition;
   noteStates: Record<string, BattleNoteState>;
@@ -124,6 +134,9 @@ export interface BattleStageState {
   comboCount: number;
   bestComboCount: number;
   comboFeedback: BattleComboFeedback | null;
+  failMeter: BattleFailMeter;
+  stageStatus: BattleStageStatus;
+  failedAtMs: number | null;
   timelineTimeMs: number;
   loopCount: number;
 }
@@ -177,6 +190,13 @@ function createInitialNoteStates(battleStage: BattleStageDefinition): Record<str
   );
 }
 
+function createInitialFailMeter(): BattleFailMeter {
+  return {
+    value: FAIL_METER_MAX_VALUE,
+    maxValue: FAIL_METER_MAX_VALUE
+  };
+}
+
 function getNextLoopCount(battleStage: BattleStageDefinition, elapsedTimeMs: number): number {
   return battleStage.totalDurationMs > 0
     ? Math.max(0, Math.floor(elapsedTimeMs / battleStage.totalDurationMs))
@@ -195,6 +215,10 @@ function syncBattleLoop(
   battleStage: BattleStageDefinition,
   elapsedTimeMs: number
 ): BattleStageState {
+  if (state.stageStatus === "failed") {
+    return state;
+  }
+
   const timelineTimeMs = getTimelineTimeMs(battleStage, elapsedTimeMs);
   const nextLoopCount = getNextLoopCount(battleStage, elapsedTimeMs);
 
@@ -207,6 +231,9 @@ function syncBattleLoop(
       comboCount: 0,
       bestComboCount: state.bestComboCount,
       comboFeedback: null,
+      failMeter: createInitialFailMeter(),
+      stageStatus: "playing",
+      failedAtMs: null,
       timelineTimeMs,
       loopCount: nextLoopCount
     };
@@ -239,6 +266,9 @@ export function createBattleStageState(battleStage: BattleStageDefinition): Batt
     comboCount: 0,
     bestComboCount: 0,
     comboFeedback: null,
+    failMeter: createInitialFailMeter(),
+    stageStatus: "playing",
+    failedAtMs: null,
     timelineTimeMs: 0,
     loopCount: 0
   };
@@ -269,6 +299,24 @@ function breakCombo(
   };
 }
 
+function applyMissPenalty(
+  state: BattleStageState,
+  lastJudgment: BattleJudgmentEvent
+): BattleStageState {
+  const nextFailMeterValue = Math.max(0, state.failMeter.value - FAIL_METER_DRAIN_PER_MISS);
+  const stageStatus = nextFailMeterValue === 0 ? "failed" : state.stageStatus;
+
+  return {
+    ...breakCombo(state, lastJudgment),
+    failMeter: {
+      ...state.failMeter,
+      value: nextFailMeterValue
+    },
+    stageStatus,
+    failedAtMs: stageStatus === "failed" ? lastJudgment.judgedAtMs : state.failedAtMs
+  };
+}
+
 export function advanceBattleStageState(state: BattleStageState, elapsedTimeMs: number): BattleStageState {
   const { battleStage } = state;
   const loopSyncedState = syncBattleLoop(state, battleStage, elapsedTimeMs);
@@ -285,13 +333,15 @@ export function advanceBattleStageState(state: BattleStageState, elapsedTimeMs: 
       break;
     }
 
-    nextState = {
-      ...nextState,
-      noteStates: {
-        ...nextState.noteStates,
-        [note.id]: "missed"
+    nextState = applyMissPenalty(
+      {
+        ...nextState,
+        noteStates: {
+          ...nextState.noteStates,
+          [note.id]: "missed"
+        }
       },
-      lastJudgment: {
+      {
         noteId: note.id,
         itemId: note.itemId,
         laneIndex: note.laneIndex,
@@ -301,11 +351,12 @@ export function advanceBattleStageState(state: BattleStageState, elapsedTimeMs: 
         offsetMs: nextState.timelineTimeMs - note.hitTimeMs,
         outcome: "missed-window",
         consumedNote: true
-      },
-      hitFeedback: null,
-      comboCount: 0,
-      comboFeedback: null
-    };
+      }
+    );
+
+    if (nextState.stageStatus === "failed") {
+      break;
+    }
   }
 
   return nextState;
@@ -316,6 +367,10 @@ export function judgeBattleStageInput(
   elapsedTimeMs: number,
   key: string
 ): BattleStageState {
+  if (state.stageStatus === "failed") {
+    return state;
+  }
+
   const { battleStage } = state;
   const loopSyncedState = syncBattleLoop(state, battleStage, elapsedTimeMs);
   const targetNote = getFirstPendingNote(battleStage, loopSyncedState.noteStates);
@@ -334,7 +389,15 @@ export function judgeBattleStageInput(
   const offsetMs = loopSyncedState.timelineTimeMs - targetNote.hitTimeMs;
 
   if (offsetMs > HIT_WINDOW_MS) {
-    return breakCombo(advancedState, {
+    return applyMissPenalty(
+      {
+        ...advancedState,
+        noteStates: {
+          ...advancedState.noteStates,
+          [targetNote.id]: "missed"
+        }
+      },
+      {
         noteId: targetNote.id,
         itemId: targetNote.itemId,
         laneIndex: targetNote.laneIndex,
@@ -344,7 +407,8 @@ export function judgeBattleStageInput(
         offsetMs,
         outcome: "missed-window",
         consumedNote: true
-      });
+      }
+    );
   }
 
   if (offsetMs < -HIT_WINDOW_MS) {
@@ -404,6 +468,13 @@ export function judgeBattleStageInput(
     },
     comboCount,
     bestComboCount: Math.max(advancedState.bestComboCount, comboCount),
+    failMeter: {
+      ...advancedState.failMeter,
+      value: Math.min(
+        advancedState.failMeter.maxValue,
+        advancedState.failMeter.value + FAIL_METER_RECOVERY_PER_HIT
+      )
+    },
     comboFeedback: {
       comboCount,
       milestoneThreshold,
@@ -411,6 +482,13 @@ export function judgeBattleStageInput(
       endsAtMs: loopSyncedState.timelineTimeMs + COMBO_FEEL_DURATION_MS,
       label: formatComboLabel(comboCount, milestoneThreshold)
     }
+  };
+}
+
+export function restartBattleStage(state: BattleStageState): BattleStageState {
+  return {
+    ...createBattleStageState(state.battleStage),
+    bestComboCount: state.bestComboCount
   };
 }
 
@@ -498,7 +576,7 @@ export function getBattleStageSnapshot(
   elapsedTimeMs: number,
   state?: BattleStageState
 ): BattleStageSnapshot {
-  const timelineTimeMs = getTimelineTimeMs(battleStage, elapsedTimeMs);
+  const timelineTimeMs = state?.timelineTimeMs ?? getTimelineTimeMs(battleStage, elapsedTimeMs);
   const activePhrase =
     battleStage.phrases.find(
       (phrase) =>

--- a/packages/runtime/src/battle-stage.ts
+++ b/packages/runtime/src/battle-stage.ts
@@ -576,7 +576,10 @@ export function getBattleStageSnapshot(
   elapsedTimeMs: number,
   state?: BattleStageState
 ): BattleStageSnapshot {
-  const timelineTimeMs = state?.timelineTimeMs ?? getTimelineTimeMs(battleStage, elapsedTimeMs);
+  const timelineTimeMs =
+    state?.stageStatus === "failed"
+      ? state.timelineTimeMs
+      : getTimelineTimeMs(battleStage, elapsedTimeMs);
   const activePhrase =
     battleStage.phrases.find(
       (phrase) =>

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -13,10 +13,12 @@ export { BootScene } from "./scenes/BootScene";
 export {
   advanceBattleStageState,
   type BattleComboFeedback,
+  type BattleFailMeter,
   createBattleStageDefinition,
   createBattleStageState,
   getBattleStageSnapshot,
   judgeBattleStageInput,
+  restartBattleStage,
   type BattleHitFeedback,
   type BattleJudgmentEvent,
   type BattleJudgmentOutcome,
@@ -26,6 +28,7 @@ export {
   type BattleNoteState,
   type BattleStageDefinition,
   type BattleStageSnapshot,
+  type BattleStageStatus,
   type BattleStageState
 } from "./battle-stage";
 export {

--- a/packages/runtime/src/scenes/BootScene.ts
+++ b/packages/runtime/src/scenes/BootScene.ts
@@ -5,6 +5,7 @@ import {
   createBattleStageState,
   getBattleStageSnapshot,
   judgeBattleStageInput,
+  restartBattleStage,
   type BattleStageDefinition,
   type BattleStageState
 } from "../battle-stage";
@@ -19,6 +20,9 @@ const RECEPTOR_ACTIVE_FILL = 0xffcf88;
 const COMBO_IDLE_COLOR = "#d6dee8";
 const COMBO_HIT_COLOR = "#f6efe5";
 const COMBO_MILESTONE_COLOR = "#ffcf88";
+const FAIL_METER_FRAME_FILL = 0x0f1724;
+const FAIL_METER_FILL = 0xff8b7c;
+const FAIL_METER_SAFE_FILL = 0x7ef0ad;
 const JUDGMENT_COLORS = {
   hit: "#7ef0ad",
   "wrong-lane": "#ff8b7c",
@@ -38,6 +42,10 @@ export class BootScene extends Phaser.Scene {
   private inputLegendText!: Phaser.GameObjects.Text;
   private judgmentText!: Phaser.GameObjects.Text;
   private comboText!: Phaser.GameObjects.Text;
+  private failMeterLabelText!: Phaser.GameObjects.Text;
+  private failMeterValueText!: Phaser.GameObjects.Text;
+  private failMeterFill!: Phaser.GameObjects.Rectangle;
+  private failureOverlay!: Phaser.GameObjects.Container;
   private receptorSprites: Phaser.GameObjects.Rectangle[] = [];
   private noteSprites = new Map<string, Phaser.GameObjects.Rectangle>();
   private activeItemId: string | null = null;
@@ -180,6 +188,27 @@ export class BootScene extends Phaser.Scene {
         fontFamily: "Trebuchet MS, Verdana, sans-serif",
         fontSize: "14px"
       });
+    this.failMeterLabelText = this.add
+      .text(playfield.left + 20, playfield.top + 82, "Fail meter", {
+        color: "#f6efe5",
+        fontFamily: "Trebuchet MS, Verdana, sans-serif",
+        fontSize: "15px",
+        fontStyle: "bold"
+      });
+    this.add
+      .rectangle(playfield.left + 90, playfield.top + 112, 140, 16, FAIL_METER_FRAME_FILL, 1)
+      .setOrigin(0, 0.5)
+      .setStrokeStyle(2, 0xffffff, 0.12);
+    this.failMeterFill = this.add
+      .rectangle(playfield.left + 92, playfield.top + 112, 136, 12, FAIL_METER_SAFE_FILL, 1)
+      .setOrigin(0, 0.5);
+    this.failMeterValueText = this.add
+      .text(playfield.left + 238, playfield.top + 112, "100%", {
+        color: "#d6dee8",
+        fontFamily: "Trebuchet MS, Verdana, sans-serif",
+        fontSize: "14px"
+      })
+      .setOrigin(1, 0.5);
     this.comboText = this.add
       .text(playfield.right - 20, playfield.top + 34, "Combo x0", {
         color: COMBO_IDLE_COLOR,
@@ -233,6 +262,50 @@ export class BootScene extends Phaser.Scene {
 
       this.noteSprites.set(note.id, sprite);
     });
+
+    const overlayWidth = 320;
+    const overlayHeight = 180;
+    const overlayCenterX = playfield.left + playfield.width / 2;
+    const overlayCenterY = playfield.top + playfield.height / 2;
+    const overlayBackground = this.add
+      .rectangle(0, 0, overlayWidth, overlayHeight, 0x0d1624, 0.94)
+      .setStrokeStyle(2, 0xff8b7c, 0.4);
+    const overlayTitle = this.add
+      .text(0, -44, "Stage failed", {
+        color: "#f6efe5",
+        fontFamily: "Trebuchet MS, Verdana, sans-serif",
+        fontSize: "28px",
+        fontStyle: "bold"
+      })
+      .setOrigin(0.5);
+    const overlayBody = this.add
+      .text(0, 0, "Press R or Enter to retry instantly.", {
+        color: "#d6dee8",
+        fontFamily: "Trebuchet MS, Verdana, sans-serif",
+        fontSize: "18px",
+        align: "center",
+        wordWrap: { width: overlayWidth - 48 }
+      })
+      .setOrigin(0.5);
+    const overlayHint = this.add
+      .text(0, 48, "The chart restarts without reloading the page.", {
+        color: "#ffcf88",
+        fontFamily: "Trebuchet MS, Verdana, sans-serif",
+        fontSize: "14px",
+        align: "center",
+        wordWrap: { width: overlayWidth - 48 }
+      })
+      .setOrigin(0.5);
+
+    this.failureOverlay = this.add
+      .container(overlayCenterX, overlayCenterY, [
+        overlayBackground,
+        overlayTitle,
+        overlayBody,
+        overlayHint
+      ])
+      .setDepth(10)
+      .setVisible(false);
   }
 
   private refreshFrame(elapsedTimeMs: number) {
@@ -259,6 +332,8 @@ export class BootScene extends Phaser.Scene {
     this.renderHitFeedback();
     this.renderJudgmentFeedback();
     this.renderComboFeedback();
+    this.renderFailMeter();
+    this.renderFailurePrompt();
   }
 
   private renderActiveCue(activeItemId: string | null) {
@@ -280,6 +355,18 @@ export class BootScene extends Phaser.Scene {
   }
 
   private handleKeyDown = (event: KeyboardEvent) => {
+    if (
+      this.battleState.stageStatus === "failed" &&
+      (event.key === "r" || event.key === "R" || event.key === "Enter")
+    ) {
+      this.battleState = restartBattleStage(this.battleState);
+      this.sceneStartTimeMs = this.time.now;
+      this.activeItemId = null;
+      this.refreshFrame(0);
+
+      return;
+    }
+
     const laneIndex = this.battleStage.lanes.findIndex((lane) => lane.key === event.key);
 
     if (laneIndex === -1) {
@@ -312,6 +399,12 @@ export class BootScene extends Phaser.Scene {
   }
 
   private renderJudgmentFeedback() {
+    if (this.battleState.stageStatus === "failed") {
+      this.judgmentText.setColor("#ff8b7c").setText("Missed too many notes");
+
+      return;
+    }
+
     const hitFeedback = this.battleState.hitFeedback;
 
     if (hitFeedback !== null && this.battleState.timelineTimeMs <= hitFeedback.endsAtMs) {
@@ -366,6 +459,25 @@ export class BootScene extends Phaser.Scene {
       )
       .setFontSize(fontSize)
       .setScale(1, 1);
+  }
+
+  private renderFailMeter() {
+    const { failMeter } = this.battleState;
+    const ratio = failMeter.maxValue > 0 ? failMeter.value / failMeter.maxValue : 0;
+    const fillWidth = Math.max(0, 136 * ratio);
+    const fillColor = ratio <= 0.35 ? FAIL_METER_FILL : FAIL_METER_SAFE_FILL;
+
+    this.failMeterFill.setDisplaySize(fillWidth, 12).setFillStyle(fillColor, 1);
+    this.failMeterLabelText.setText(
+      this.battleState.stageStatus === "failed" ? "Fail meter empty" : "Fail meter"
+    );
+    this.failMeterValueText.setText(`${Math.round(ratio * 100)}%`).setColor(
+      this.battleState.stageStatus === "failed" ? "#ff8b7c" : "#d6dee8"
+    );
+  }
+
+  private renderFailurePrompt() {
+    this.failureOverlay.setVisible(this.battleState.stageStatus === "failed");
   }
 
   private getImageKey(index: number) {


### PR DESCRIPTION
## Summary
- add battle-stage fail meter state, stage failure, and instant restart support
- render a visible fail meter and retry prompt in the Phaser battle scene
- add a focused regression for failure depletion and retry reset

## Testing
- pnpm --filter @fne/web test -- src/battleStage.test.ts
- pnpm test
- pnpm lint
- pnpm typecheck
- pnpm --filter @fne/web build

Refs #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fail meter that drains on missed notes and recovers on successful hits.
  * Stage transitions to a "failed" state when the fail meter is fully depleted.
  * Added instant retry functionality: press R or Enter to immediately restart the stage while preserving performance metrics.
  * Added visual fail meter UI display with failure overlay prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->