### PR TITLE
Epic 14.6 - Implement vocabulary cue cadence inside Battle Mode slice (#140)

### DIFF
--- a/.codex-supervisor/issues/140/issue-journal.md
+++ b/.codex-supervisor/issues/140/issue-journal.md
@@ -1,0 +1,35 @@
+# Issue #140: Epic 14.6 - Implement vocabulary cue cadence inside Battle Mode slice
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/FNE/issues/140
+- Branch: codex/issue-140
+- Workspace: .
+- Journal: .codex-supervisor/issues/140/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 61ae27e0cb358972a7ee67021fa96f20506512fc
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-19T07:26:13.513Z
+
+## Latest Codex Summary
+- Reproduced the missing cadence boundary by adding a focused `battleStage` regression test that expected cue-level preview and phrase ownership from the runtime snapshot.
+- Implemented `activeCue` snapshot data with `preview` vs `phrase` phase metadata, then updated `BootScene` to render the cue panel from that authoritative cadence surface and only replay pronunciation audio at preview start.
+- Verification in this turn: `pnpm --filter @fne/web test -- src/battleStage.test.ts`, `pnpm run typecheck`, and `pnpm run lint` all pass after installing workspace dependencies.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Battle Mode already tracked phrase timing internally, but the exported snapshot did not expose cue-level cadence state, so the UI could not prove preview-first vocabulary ownership at the real rendering boundary.
+- What changed: Added a failing regression test for cue cadence, extended `BattlePhraseDefinition`/`BattleStageSnapshot` with authoritative `activeCue` metadata, and updated `BootScene` to render preview-vs-phrase cue text from that metadata while replaying pronunciation only on preview entry.
+- Current blocker: none
+- Next exact step: create a checkpoint commit for the cadence slice and leave the branch ready for supervisor review or draft PR creation.
+- Verification gap: manual live-play readability review under hit/combo feedback is still not exercised by automated tests in this turn.
+- Files touched: `apps/web/src/battleStage.test.ts`, `packages/runtime/src/battle-stage.ts`, `packages/runtime/src/scenes/BootScene.ts`
+- Rollback concern: the new `activeCue` snapshot surface is now the authoritative cue contract for the Battle Mode scene, so any rollback should revert the test and scene usage together.
+- Last focused command: `pnpm run lint`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/apps/web/src/battleStage.test.ts
+++ b/apps/web/src/battleStage.test.ts
@@ -71,6 +71,84 @@ describe("battle stage baseline", () => {
     expect(hitNote?.y).toBeCloseTo(hitNote?.receptorY ?? -1, 1);
   });
 
+  it("keeps one vocabulary cue active through preview and phrase timing before handing off cleanly", () => {
+    const runtimeStage = loadDemoRuntimeStage();
+    const battleStage = createBattleStageDefinition(runtimeStage);
+    const [firstPhrase, secondPhrase] = battleStage.phrases;
+    const firstPhraseNotes = battleStage.notes.filter((note) => note.itemId === firstPhrase?.itemId);
+
+    expect(firstPhrase).toBeDefined();
+    expect(secondPhrase).toBeDefined();
+    expect(firstPhraseNotes.length).toBeGreaterThan(0);
+
+    if (
+      firstPhrase === undefined ||
+      secondPhrase === undefined ||
+      firstPhraseNotes.length === 0
+    ) {
+      throw new Error("expected the battle stage to provide at least two vocabulary phrases");
+    }
+
+    const firstRuntimeItem = runtimeStage.items[0];
+    const firstPhraseAnchor = firstPhraseNotes[0];
+    const lastPhraseNote = firstPhraseNotes.at(-1);
+
+    expect(firstRuntimeItem).toBeDefined();
+    expect(firstPhraseAnchor).toBeDefined();
+    expect(lastPhraseNote).toBeDefined();
+
+    if (
+      firstRuntimeItem === undefined ||
+      firstPhraseAnchor === undefined ||
+      lastPhraseNote === undefined
+    ) {
+      throw new Error("expected demo runtime content to provide a playable first battle cue");
+    }
+
+    const previewSnapshot = getBattleStageSnapshot(battleStage, firstPhrase.previewStartTimeMs);
+    const phraseSnapshot = getBattleStageSnapshot(battleStage, lastPhraseNote.hitTimeMs);
+    const carriedCueState = judgeBattleStageInput(
+      createBattleStageState(battleStage),
+      firstPhraseAnchor.hitTimeMs,
+      battleStage.lanes[firstPhraseAnchor.laneIndex]?.key ?? "ArrowLeft"
+    );
+    const cueUnderFeedbackSnapshot = getBattleStageSnapshot(
+      battleStage,
+      firstPhraseAnchor.hitTimeMs,
+      carriedCueState
+    );
+    const handoffSnapshot = getBattleStageSnapshot(battleStage, secondPhrase.previewStartTimeMs);
+
+    expect(previewSnapshot.activeCue).toMatchObject({
+      itemId: firstPhrase.itemId,
+      phase: "preview",
+      term: firstRuntimeItem.item.term,
+      meaning: firstRuntimeItem.item.meaning,
+      pronunciation: firstRuntimeItem.item.pronunciation,
+      imageSrc: firstRuntimeItem.imageSrc
+    });
+    expect(previewSnapshot.activeCue?.previewEndsAtMs).toBe(firstPhrase.previewEndTimeMs);
+    expect(previewSnapshot.activeCue?.phraseEndsAtMs).toBe(firstPhrase.phraseEndTimeMs);
+
+    expect(phraseSnapshot.activeCue).toMatchObject({
+      itemId: firstPhrase.itemId,
+      phase: "phrase"
+    });
+    expect(phraseSnapshot.activeItemId).toBe(firstPhrase.itemId);
+
+    expect(cueUnderFeedbackSnapshot.activeCue).toMatchObject({
+      itemId: firstPhrase.itemId,
+      phase: "phrase"
+    });
+    expect(carriedCueState.hitFeedback).not.toBeNull();
+
+    expect(handoffSnapshot.activeCue).toMatchObject({
+      itemId: secondPhrase.itemId,
+      phase: "preview"
+    });
+    expect(handoffSnapshot.activeItemId).toBe(secondPhrase.itemId);
+  });
+
   it("registers a hit when the matching lane key lands inside the timing window", () => {
     const battleStage = createBattleStageDefinition(loadDemoRuntimeStage());
     const note = battleStage.notes[0];

--- a/packages/runtime/src/battle-stage.ts
+++ b/packages/runtime/src/battle-stage.ts
@@ -50,6 +50,11 @@ export interface BattleLaneDefinition {
 
 export interface BattlePhraseDefinition {
   itemId: string;
+  term: string;
+  meaning: string;
+  pronunciation: string;
+  imageSrc: string;
+  audioSrc: string;
   previewStartTimeMs: number;
   previewEndTimeMs: number;
   phraseEndTimeMs: number;
@@ -85,7 +90,22 @@ export interface BattleNoteSnapshot extends BattleNoteDefinition {
 
 export interface BattleStageSnapshot {
   activeItemId: string | null;
+  activeCue: BattleActiveCueSnapshot | null;
   notes: BattleNoteSnapshot[];
+}
+
+export type BattleCuePhase = "preview" | "phrase";
+
+export interface BattleActiveCueSnapshot {
+  itemId: string;
+  term: string;
+  meaning: string;
+  pronunciation: string;
+  imageSrc: string;
+  audioSrc: string;
+  phase: BattleCuePhase;
+  previewEndsAtMs: number;
+  phraseEndsAtMs: number;
 }
 
 export type BattleNoteState = "pending" | "hit" | "missed";
@@ -553,6 +573,11 @@ export function createBattleStageDefinition(stage: RuntimeStage): BattleStageDef
 
     phrases.push({
       itemId: runtimeItem.item.id,
+      term: runtimeItem.item.term,
+      meaning: runtimeItem.item.meaning,
+      pronunciation: runtimeItem.item.pronunciation,
+      imageSrc: runtimeItem.imageSrc,
+      audioSrc: runtimeItem.audioSrc,
       previewStartTimeMs,
       previewEndTimeMs: phraseStartTimeMs,
       phraseEndTimeMs
@@ -586,6 +611,20 @@ export function getBattleStageSnapshot(
         timelineTimeMs >= phrase.previewStartTimeMs &&
         timelineTimeMs < phrase.phraseEndTimeMs + PREVIEW_RECOVERY_MS
     ) ?? null;
+  const activeCue =
+    activePhrase === null
+      ? null
+      : {
+          itemId: activePhrase.itemId,
+          term: activePhrase.term,
+          meaning: activePhrase.meaning,
+          pronunciation: activePhrase.pronunciation,
+          imageSrc: activePhrase.imageSrc,
+          audioSrc: activePhrase.audioSrc,
+          phase: timelineTimeMs < activePhrase.previewEndTimeMs ? "preview" : "phrase",
+          previewEndsAtMs: activePhrase.previewEndTimeMs,
+          phraseEndsAtMs: activePhrase.phraseEndTimeMs
+        } satisfies BattleActiveCueSnapshot;
   const notes = battleStage.notes.map((note) => {
     const lane = battleStage.lanes[note.laneIndex];
     const rawProgress = (timelineTimeMs - note.spawnTimeMs) / note.travelDurationMs;
@@ -609,7 +648,8 @@ export function getBattleStageSnapshot(
   });
 
   return {
-    activeItemId: activePhrase?.itemId ?? null,
+    activeItemId: activeCue?.itemId ?? null,
+    activeCue,
     notes
   };
 }

--- a/packages/runtime/src/scenes/BootScene.ts
+++ b/packages/runtime/src/scenes/BootScene.ts
@@ -6,6 +6,7 @@ import {
   getBattleStageSnapshot,
   judgeBattleStageInput,
   restartBattleStage,
+  type BattleActiveCueSnapshot,
   type BattleStageDefinition,
   type BattleStageState
 } from "../battle-stage";
@@ -49,6 +50,7 @@ export class BootScene extends Phaser.Scene {
   private receptorSprites: Phaser.GameObjects.Rectangle[] = [];
   private noteSprites = new Map<string, Phaser.GameObjects.Rectangle>();
   private activeItemId: string | null = null;
+  private activeCuePhase: BattleActiveCueSnapshot["phase"] | null = null;
   private itemsById = new Map<string, RuntimeDemoItem>();
 
   constructor() {
@@ -324,9 +326,13 @@ export class BootScene extends Phaser.Scene {
       sprite.setAlpha(note.isVisible ? 0.96 : 0);
     });
 
-    if (snapshot.activeItemId !== this.activeItemId) {
-      this.activeItemId = snapshot.activeItemId;
-      this.renderActiveCue(snapshot.activeItemId);
+    if (
+      snapshot.activeCue?.itemId !== this.activeItemId ||
+      snapshot.activeCue?.phase !== this.activeCuePhase
+    ) {
+      this.activeItemId = snapshot.activeCue?.itemId ?? null;
+      this.activeCuePhase = snapshot.activeCue?.phase ?? null;
+      this.renderActiveCue(snapshot.activeCue);
     }
 
     this.renderHitFeedback();
@@ -336,22 +342,40 @@ export class BootScene extends Phaser.Scene {
     this.renderFailurePrompt();
   }
 
-  private renderActiveCue(activeItemId: string | null) {
-    const runtimeItem = activeItemId === null ? undefined : this.itemsById.get(activeItemId);
+  private renderActiveCue(activeCue: BattleActiveCueSnapshot | null) {
+    if (activeCue === null) {
+      return;
+    }
+
+    const runtimeItem = this.itemsById.get(activeCue.itemId);
 
     if (runtimeItem === undefined) {
       return;
     }
 
-    const itemIndex = this.runtimeStage.items.findIndex((candidate) => candidate.item.id === activeItemId);
+    const itemIndex = this.runtimeStage.items.findIndex(
+      (candidate) => candidate.item.id === activeCue.itemId
+    );
+    const isPreviewPhase = activeCue.phase === "preview";
+    const phaseLabel = isPreviewPhase
+      ? "Pronunciation preview before the phrase"
+      : "Phrase cue stays stable through the notes";
 
     this.cueImageFrame.setTexture(this.getImageKey(itemIndex));
-    this.cueMeaningText.setText(runtimeItem.item.meaning);
-    this.cueWordText.setText(runtimeItem.item.term.toUpperCase());
-    this.cuePronunciationText.setText(runtimeItem.item.pronunciation);
-    this.inputLegendText.setText(`Keys: Left / Down / Up / Right\nActive cue: ${runtimeItem.item.term}`);
-    this.sound.stopAll();
-    this.sound.play(this.getAudioKey(itemIndex));
+    this.cueMeaningText.setText(activeCue.meaning);
+    this.cueWordText
+      .setText(activeCue.term.toUpperCase())
+      .setFontSize(isPreviewPhase ? "18px" : "20px")
+      .setAlpha(isPreviewPhase ? 0.78 : 0.88);
+    this.cuePronunciationText.setText(`${activeCue.pronunciation} • ${phaseLabel}`);
+    this.inputLegendText.setText(
+      `Keys: Left / Down / Up / Right\nActive cue: ${activeCue.term}`
+    );
+
+    if (isPreviewPhase) {
+      this.sound.stopAll();
+      this.sound.play(this.getAudioKey(itemIndex));
+    }
   }
 
   private handleKeyDown = (event: KeyboardEvent) => {
@@ -362,6 +386,7 @@ export class BootScene extends Phaser.Scene {
       this.battleState = restartBattleStage(this.battleState);
       this.sceneStartTimeMs = this.time.now;
       this.activeItemId = null;
+      this.activeCuePhase = null;
       this.refreshFrame(0);
 
       return;


### PR DESCRIPTION
Closes #140
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the Battle Mode cue cadence slice at the runtime boundary and scene layer.

The key change is that `getBattleStageSnapshot()` now exposes an authoritative `activeCue` with `preview` versus `phrase` phase metadata, plus the cue content needed by the UI. That let me add a focused regression in [battleStage.test.ts](/Users/tomoakikawada/Dev/FNE/FNE-codex-supervisor/.local/worktrees/issue-140/apps/web/src/battleStage.test.ts) proving preview-first ownership, phrase-stable cue continuity, and clean handoff to the next word. I then updated [battle-stage.ts](/Users/tomoakikawada/Dev/FNE/FNE-codex-supervisor/.local/worktrees/issue-140/packages/runtime/src/battle-stage.ts) and [BootScene.ts](/Users/tomoakikawada/Dev/FNE/FNE-codex-supervisor/.local/worktrees/issue-140/packages/runtime/src/scenes/BootScene.ts) so the cue panel renders from that snapshot and only replays pronunciation at preview start instead of treating the cue as a generic item switch.

I also updated the issue journal and created checkpoint commit `804b4af` with message `Implement battle cue cadence snapshot`.

Summary: Added an authoritative Battle Mode `activeCue` snapshot with preview/phrase cadence, covered it with a focused regression test, and wired the scene to render pronunciation preview and phrase-stable cue ownership from that surface.
State hint: implementing
Blocked reason: none
Tests: `pnpm --filter @fne/web test -- src/battleStage.test.ts`; `pnpm run typecheck`; `pnpm run lint`
Failure si...