### PR TITLE
Epic 14.7 - Add Battle Mode feel-tuning hooks and smoke verification (#143)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The lint and typecheck gate expectations live in [docs/validation-gates.md](docs
 Install dependencies with `pnpm install`, then use the repo validation scripts directly:
 
 - `pnpm run smoke:learn-mode` verifies the Learn Mode doc contract plus the stage-level reveal, retry, and summary progression path.
+- `pnpm run smoke:battle-mode` verifies the Battle Mode doc contract plus the tunable hit, miss, combo, fail, and retry path.
 - `pnpm run smoke:runtime` verifies the runtime skeleton still boots the Phaser shell and tears down cleanly.
 - `pnpm run typecheck` runs the TypeScript gate.
 - `pnpm run lint` runs the lint gate.

--- a/apps/web/src/battleStage.test.ts
+++ b/apps/web/src/battleStage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_BATTLE_STAGE_TUNING,
   advanceBattleStageState,
   createBattleStageDefinition,
   createBattleStageState,
@@ -10,6 +11,67 @@ import {
 import { loadDemoRuntimeStage } from "@fne/runtime/demo-content";
 
 describe("battle stage baseline", () => {
+  it("accepts focused feel-tuning overrides without rewriting battle flow setup", () => {
+    const tunedBattleStage = createBattleStageDefinition(loadDemoRuntimeStage(), {
+      noteTravelMs: 1400,
+      hitWindowMs: 240,
+      hitFeedbackDurationMs: 90,
+      comboFeedbackDurationMs: 320,
+      comboMilestoneThresholds: [2, 4, 6]
+    });
+    const [firstNote, secondNote, thirdNote, fourthNote] = tunedBattleStage.notes;
+
+    expect(firstNote).toBeDefined();
+    expect(secondNote).toBeDefined();
+    expect(thirdNote).toBeDefined();
+    expect(fourthNote).toBeDefined();
+
+    if (
+      firstNote === undefined ||
+      secondNote === undefined ||
+      thirdNote === undefined ||
+      fourthNote === undefined
+    ) {
+      throw new Error("expected the tuned battle stage to schedule at least four notes");
+    }
+
+    expect(tunedBattleStage.tuning).toMatchObject({
+      ...DEFAULT_BATTLE_STAGE_TUNING,
+      noteTravelMs: 1400,
+      hitWindowMs: 240,
+      hitFeedbackDurationMs: 90,
+      comboFeedbackDurationMs: 320,
+      comboMilestoneThresholds: [2, 4, 6]
+    });
+    expect(firstNote.travelDurationMs).toBe(1400);
+    expect(firstNote.spawnTimeMs).toBe(firstNote.hitTimeMs - 1400);
+
+    const lane = tunedBattleStage.lanes[firstNote.laneIndex];
+    const earlyHit = judgeBattleStageInput(
+      createBattleStageState(tunedBattleStage),
+      firstNote.hitTimeMs - 220,
+      lane.key
+    );
+
+    expect(earlyHit.lastJudgment?.outcome).toBe("hit");
+    expect(earlyHit.hitFeedback?.endsAtMs).toBe(firstNote.hitTimeMs - 220 + 90);
+
+    const secondHit = judgeBattleStageInput(earlyHit, secondNote.hitTimeMs, tunedBattleStage.lanes[secondNote.laneIndex].key);
+    expect(secondHit.comboFeedback).toMatchObject({
+      comboCount: 2,
+      milestoneThreshold: 2,
+      endsAtMs: secondNote.hitTimeMs + 320
+    });
+
+    const thirdHit = judgeBattleStageInput(secondHit, thirdNote.hitTimeMs, tunedBattleStage.lanes[thirdNote.laneIndex].key);
+    const fourthHit = judgeBattleStageInput(thirdHit, fourthNote.hitTimeMs, tunedBattleStage.lanes[fourthNote.laneIndex].key);
+
+    expect(fourthHit.comboFeedback).toMatchObject({
+      comboCount: 4,
+      milestoneThreshold: 4
+    });
+  });
+
   it("builds four fixed learner lanes with stable receptors and keyboard mapping", () => {
     const battleStage = createBattleStageDefinition(loadDemoRuntimeStage());
 

--- a/docs/battle-mode.md
+++ b/docs/battle-mode.md
@@ -134,3 +134,11 @@ Define the FNF-style competitive rhythm mode so implementation can build lane fl
 - The first implementation should remain compatible with the browser-first runtime split in [docs/architecture.md](architecture.md): Phaser owns chart timing and hit detection, while React may own surrounding HUD, prompts, and retry flow.
 - Battle Mode baseline review should confirm the hit-feel spec keeps the sync contract explicit for judgment timing, hit confirmation sound, receptor feedback, lane feedback, and animation alignment.
 - If a later issue needs opponent AI, multiple judgment tiers, or difficulty variants, that work should extend this spec rather than replace the four-lane, four-count vocabulary battle baseline.
+
+## Local Feel-Tuning Loop
+
+- Battle feel parameters should stay adjustable through the exported `DEFAULT_BATTLE_STAGE_TUNING` seam in `packages/runtime/src/battle-stage.ts`.
+- The baseline tuning surface covers BPM, preview recovery, note travel speed, hit window tolerance, hit feedback duration, combo feedback duration, combo milestone thresholds, and fail-meter gain and drain values.
+- Local feel iteration should start by overriding only the narrow parameter under review in a focused test or harness instead of restructuring stage generation or judgment flow.
+- Run `pnpm run smoke:battle-mode` after `pnpm install` to verify the Battle Mode doc contract plus the implemented hit, miss, combo, fail, and retry path.
+- Run `pnpm run smoke:runtime` alongside the Battle smoke when you need to confirm the browser runtime still mounts cleanly after tuning changes.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "scripts": {
+    "smoke:battle-mode": "sh ./scripts/smoke-battle-mode.sh",
     "lint": "pnpm exec eslint apps packages --ext .ts,.tsx",
     "smoke:learn-mode": "sh ./scripts/smoke-learn-mode.sh",
     "smoke:runtime": "pnpm --filter @fne/web test -- src/runtimeSmoke.test.ts",

--- a/packages/runtime/src/battle-stage.ts
+++ b/packages/runtime/src/battle-stage.ts
@@ -16,16 +16,32 @@ const PLAYFIELD_HEIGHT_PX = SHELL_HEIGHT_PX - 80;
 const LANE_GAP_PX = 16;
 const RECEPTOR_OFFSET_PX = 74;
 const NOTE_SPAWN_TOP_PX = PLAYFIELD_TOP_PX + 112;
-const DEFAULT_BPM = 100;
-const PREVIEW_RECOVERY_MS = 900;
-const NOTE_TRAVEL_MS = 2200;
-const HIT_WINDOW_MS = 180;
-const HIT_FEEL_DURATION_MS = 120;
-const COMBO_FEEL_DURATION_MS = 240;
-const COMBO_MILESTONE_THRESHOLDS = [3, 5, 10] as const;
-const FAIL_METER_MAX_VALUE = 100;
-const FAIL_METER_DRAIN_PER_MISS = 25;
-const FAIL_METER_RECOVERY_PER_HIT = 8;
+
+export interface BattleStageTuning {
+  bpm: number;
+  previewRecoveryMs: number;
+  noteTravelMs: number;
+  hitWindowMs: number;
+  hitFeedbackDurationMs: number;
+  comboFeedbackDurationMs: number;
+  comboMilestoneThresholds: number[];
+  failMeterMaxValue: number;
+  failMeterDrainPerMiss: number;
+  failMeterRecoveryPerHit: number;
+}
+
+export const DEFAULT_BATTLE_STAGE_TUNING: BattleStageTuning = Object.freeze({
+  bpm: 100,
+  previewRecoveryMs: 900,
+  noteTravelMs: 2200,
+  hitWindowMs: 180,
+  hitFeedbackDurationMs: 120,
+  comboFeedbackDurationMs: 240,
+  comboMilestoneThresholds: [3, 5, 10],
+  failMeterMaxValue: 100,
+  failMeterDrainPerMiss: 25,
+  failMeterRecoveryPerHit: 8
+});
 
 export type BattleLaneDirection = (typeof BATTLE_LANE_DIRECTIONS)[number];
 
@@ -76,6 +92,7 @@ export interface BattleStageDefinition {
   phrases: BattlePhraseDefinition[];
   notes: BattleNoteDefinition[];
   totalDurationMs: number;
+  tuning: BattleStageTuning;
 }
 
 export interface BattleNoteSnapshot extends BattleNoteDefinition {
@@ -133,7 +150,7 @@ export interface BattleHitFeedback {
 
 export interface BattleComboFeedback {
   comboCount: number;
-  milestoneThreshold: (typeof COMBO_MILESTONE_THRESHOLDS)[number] | null;
+  milestoneThreshold: number | null;
   startedAtMs: number;
   endsAtMs: number;
   label: string;
@@ -210,10 +227,10 @@ function createInitialNoteStates(battleStage: BattleStageDefinition): Record<str
   );
 }
 
-function createInitialFailMeter(): BattleFailMeter {
+function createInitialFailMeter(tuning: BattleStageTuning): BattleFailMeter {
   return {
-    value: FAIL_METER_MAX_VALUE,
-    maxValue: FAIL_METER_MAX_VALUE
+    value: tuning.failMeterMaxValue,
+    maxValue: tuning.failMeterMaxValue
   };
 }
 
@@ -251,7 +268,7 @@ function syncBattleLoop(
       comboCount: 0,
       bestComboCount: state.bestComboCount,
       comboFeedback: null,
-      failMeter: createInitialFailMeter(),
+      failMeter: createInitialFailMeter(battleStage.tuning),
       stageStatus: "playing",
       failedAtMs: null,
       timelineTimeMs,
@@ -286,7 +303,7 @@ export function createBattleStageState(battleStage: BattleStageDefinition): Batt
     comboCount: 0,
     bestComboCount: 0,
     comboFeedback: null,
-    failMeter: createInitialFailMeter(),
+    failMeter: createInitialFailMeter(battleStage.tuning),
     stageStatus: "playing",
     failedAtMs: null,
     timelineTimeMs: 0,
@@ -298,8 +315,8 @@ function formatHitConfirmationLabel(offsetMs: number): string {
   return `Hit (${offsetMs >= 0 ? "+" : ""}${offsetMs}ms)`;
 }
 
-function getComboMilestoneThreshold(comboCount: number) {
-  return COMBO_MILESTONE_THRESHOLDS.find((threshold) => threshold === comboCount) ?? null;
+function getComboMilestoneThreshold(tuning: BattleStageTuning, comboCount: number) {
+  return tuning.comboMilestoneThresholds.find((threshold) => threshold === comboCount) ?? null;
 }
 
 function formatComboLabel(comboCount: number, milestoneThreshold: number | null) {
@@ -323,7 +340,10 @@ function applyMissPenalty(
   state: BattleStageState,
   lastJudgment: BattleJudgmentEvent
 ): BattleStageState {
-  const nextFailMeterValue = Math.max(0, state.failMeter.value - FAIL_METER_DRAIN_PER_MISS);
+  const nextFailMeterValue = Math.max(
+    0,
+    state.failMeter.value - state.battleStage.tuning.failMeterDrainPerMiss
+  );
   const stageStatus = nextFailMeterValue === 0 ? "failed" : state.stageStatus;
 
   return {
@@ -347,7 +367,7 @@ export function advanceBattleStageState(state: BattleStageState, elapsedTimeMs: 
       continue;
     }
 
-    const missDeadlineMs = note.hitTimeMs + HIT_WINDOW_MS;
+    const missDeadlineMs = note.hitTimeMs + battleStage.tuning.hitWindowMs;
 
     if (nextState.timelineTimeMs <= missDeadlineMs) {
       break;
@@ -408,7 +428,7 @@ export function judgeBattleStageInput(
 
   const offsetMs = loopSyncedState.timelineTimeMs - targetNote.hitTimeMs;
 
-  if (offsetMs > HIT_WINDOW_MS) {
+  if (offsetMs > battleStage.tuning.hitWindowMs) {
     return applyMissPenalty(
       {
         ...advancedState,
@@ -431,7 +451,7 @@ export function judgeBattleStageInput(
     );
   }
 
-  if (offsetMs < -HIT_WINDOW_MS) {
+  if (offsetMs < -battleStage.tuning.hitWindowMs) {
     return breakCombo(advancedState, {
         noteId: targetNote.id,
         itemId: targetNote.itemId,
@@ -460,7 +480,7 @@ export function judgeBattleStageInput(
   }
 
   const comboCount = advancedState.comboCount + 1;
-  const milestoneThreshold = getComboMilestoneThreshold(comboCount);
+  const milestoneThreshold = getComboMilestoneThreshold(battleStage.tuning, comboCount);
 
   return {
     ...advancedState,
@@ -482,7 +502,7 @@ export function judgeBattleStageInput(
     hitFeedback: {
       laneIndex: targetNote.laneIndex,
       startedAtMs: loopSyncedState.timelineTimeMs,
-      endsAtMs: loopSyncedState.timelineTimeMs + HIT_FEEL_DURATION_MS,
+      endsAtMs: loopSyncedState.timelineTimeMs + battleStage.tuning.hitFeedbackDurationMs,
       judgmentOutcome: "hit",
       confirmationLabel: formatHitConfirmationLabel(offsetMs)
     },
@@ -492,14 +512,14 @@ export function judgeBattleStageInput(
       ...advancedState.failMeter,
       value: Math.min(
         advancedState.failMeter.maxValue,
-        advancedState.failMeter.value + FAIL_METER_RECOVERY_PER_HIT
+        advancedState.failMeter.value + battleStage.tuning.failMeterRecoveryPerHit
       )
     },
     comboFeedback: {
       comboCount,
       milestoneThreshold,
       startedAtMs: loopSyncedState.timelineTimeMs,
-      endsAtMs: loopSyncedState.timelineTimeMs + COMBO_FEEL_DURATION_MS,
+      endsAtMs: loopSyncedState.timelineTimeMs + battleStage.tuning.comboFeedbackDurationMs,
       label: formatComboLabel(comboCount, milestoneThreshold)
     }
   };
@@ -512,7 +532,29 @@ export function restartBattleStage(state: BattleStageState): BattleStageState {
   };
 }
 
-export function createBattleStageDefinition(stage: RuntimeStage): BattleStageDefinition {
+function resolveBattleStageTuning(tuningOverrides?: Partial<BattleStageTuning>): BattleStageTuning {
+  if (tuningOverrides === undefined) {
+    return {
+      ...DEFAULT_BATTLE_STAGE_TUNING,
+      comboMilestoneThresholds: [...DEFAULT_BATTLE_STAGE_TUNING.comboMilestoneThresholds]
+    };
+  }
+
+  return {
+    ...DEFAULT_BATTLE_STAGE_TUNING,
+    ...tuningOverrides,
+    comboMilestoneThresholds:
+      tuningOverrides.comboMilestoneThresholds === undefined
+        ? [...DEFAULT_BATTLE_STAGE_TUNING.comboMilestoneThresholds]
+        : [...tuningOverrides.comboMilestoneThresholds]
+  };
+}
+
+export function createBattleStageDefinition(
+  stage: RuntimeStage,
+  tuningOverrides?: Partial<BattleStageTuning>
+): BattleStageDefinition {
+  const tuning = resolveBattleStageTuning(tuningOverrides);
   const cueArea = createBounds(
     HORIZONTAL_MARGIN_PX,
     PLAYFIELD_TOP_PX,
@@ -528,7 +570,7 @@ export function createBattleStageDefinition(stage: RuntimeStage): BattleStageDef
   );
   const laneWidth = (playfield.width - LANE_GAP_PX * (BATTLE_LANE_KEYS.length - 1)) / 4;
   const receptorY = playfield.bottom - RECEPTOR_OFFSET_PX;
-  const beatDurationMs = 60_000 / DEFAULT_BPM;
+  const beatDurationMs = 60_000 / tuning.bpm;
   const lanes = BATTLE_LANE_KEYS.map((key, index) => {
     const left = playfield.left + index * (laneWidth + LANE_GAP_PX);
 
@@ -552,7 +594,7 @@ export function createBattleStageDefinition(stage: RuntimeStage): BattleStageDef
     const anchorLaneIndex = itemIndex % lanes.length;
     const lanePattern = createLanePattern(noteCount, anchorLaneIndex);
     const previewStartTimeMs = cursorMs;
-    const phraseStartTimeMs = previewStartTimeMs + NOTE_TRAVEL_MS;
+    const phraseStartTimeMs = previewStartTimeMs + tuning.noteTravelMs;
 
     lanePattern.forEach((laneIndex, noteIndex) => {
       const hitTimeMs = phraseStartTimeMs + noteIndex * beatDurationMs;
@@ -561,9 +603,9 @@ export function createBattleStageDefinition(stage: RuntimeStage): BattleStageDef
         id: `${runtimeItem.item.id}-note-${noteIndex + 1}`,
         itemId: runtimeItem.item.id,
         laneIndex,
-        spawnTimeMs: hitTimeMs - NOTE_TRAVEL_MS,
+        spawnTimeMs: hitTimeMs - tuning.noteTravelMs,
         hitTimeMs,
-        travelDurationMs: NOTE_TRAVEL_MS
+        travelDurationMs: tuning.noteTravelMs
       });
     });
 
@@ -583,7 +625,7 @@ export function createBattleStageDefinition(stage: RuntimeStage): BattleStageDef
       phraseEndTimeMs
     });
 
-    cursorMs = phraseEndTimeMs + PREVIEW_RECOVERY_MS;
+    cursorMs = phraseEndTimeMs + tuning.previewRecoveryMs;
   });
 
   return {
@@ -592,7 +634,8 @@ export function createBattleStageDefinition(stage: RuntimeStage): BattleStageDef
     lanes,
     phrases,
     notes,
-    totalDurationMs: cursorMs
+    totalDurationMs: cursorMs,
+    tuning
   };
 }
 
@@ -609,7 +652,7 @@ export function getBattleStageSnapshot(
     battleStage.phrases.find(
       (phrase) =>
         timelineTimeMs >= phrase.previewStartTimeMs &&
-        timelineTimeMs < phrase.phraseEndTimeMs + PREVIEW_RECOVERY_MS
+        timelineTimeMs < phrase.phraseEndTimeMs + battleStage.tuning.previewRecoveryMs
     ) ?? null;
   const activeCue =
     activePhrase === null

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -11,7 +11,9 @@ import {
 
 export { BootScene } from "./scenes/BootScene";
 export {
+  DEFAULT_BATTLE_STAGE_TUNING,
   advanceBattleStageState,
+  type BattleStageTuning,
   type BattleComboFeedback,
   type BattleFailMeter,
   createBattleStageDefinition,

--- a/scripts/smoke-battle-mode.sh
+++ b/scripts/smoke-battle-mode.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
+
+printf 'Running Battle Mode doc contract check...\n'
+"$script_dir/check-battle-mode.sh"
+
+printf 'Running Battle Mode runtime contract tests...\n'
+cd "$repo_root"
+pnpm --filter @fne/web test -- src/battleStage.test.ts


### PR DESCRIPTION
Closes #143
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the Battle Mode feel-tuning seam and a dedicated local smoke path, then committed the checkpoint as `4d3a47b` on `codex/issue-143`.

The runtime now exposes `DEFAULT_BATTLE_STAGE_TUNING` from [packages/runtime/src/battle-stage.ts](/Users/tomoakikawada/Dev/FNE/FNE-codex-supervisor/.local/worktrees/issue-143/packages/runtime/src/battle-stage.ts), and `createBattleStageDefinition(...)` accepts focused overrides for BPM, preview recovery, note travel speed, hit window, feedback durations, combo milestones, and fail-meter tuning without changing the Battle flow shape. I added a narrow regression in [apps/web/src/battleStage.test.ts](/Users/tomoakikawada/Dev/FNE/FNE-codex-supervisor/.local/worktrees/issue-143/apps/web/src/battleStage.test.ts) that proves those overrides affect hit timing and combo milestones. I also added [scripts/smoke-battle-mode.sh](/Users/tomoakikawada/Dev/FNE/FNE-codex-supervisor/.local/worktrees/issue-143/scripts/smoke-battle-mode.sh), wired `pnpm run smoke:battle-mode` in [package.json](/Users/tomoakikawada/Dev/FNE/FNE-codex-supervisor/.local/worktrees/issue-143/package.json), and documented the iteration loop in [README.md](/Users/tomoakikawada/Dev/FNE/FNE-codex-supervisor/.local/worktrees/issue-143/README.md) and [docs/battle-mode.md](/Users/tomoakikawada/Dev/FNE/FNE-codex-supervisor/.local/worktrees/issue-143/docs/battle-mode.md).

Local verification passed with `pnpm run smoke:battle-mode`, `pnpm run smoke:runtime`, `pnpm run typecheck`, `...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Battle Mode parameters are now adjustable for feel customization (tempo, hit window, feedback timing, combo thresholds, fail meter behavior).
  * Added `smoke:battle-mode` validation command to verify tuning changes.

* **Documentation**
  * Added Local Feel-Tuning Loop guide with parameter reference and validation workflow.

* **Tests**
  * Added comprehensive test suite for battle stage tuning overrides and feedback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->