### PR TITLE
Follow-up - Keep root lint stable after web build artifacts are generated (#151)

### DIFF
--- a/.codex-supervisor/issues/151/issue-journal.md
+++ b/.codex-supervisor/issues/151/issue-journal.md
@@ -1,0 +1,38 @@
+# Issue #151: Follow-up - Keep root lint stable after web build artifacts are generated
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/FNE/issues/151
+- Branch: codex/issue-151
+- Workspace: .
+- Journal: .codex-supervisor/issues/151/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 12282a42f0ae305dc442577912239d63ef23d1ea
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-19T09:10:45.545Z
+
+## Latest Codex Summary
+- Reproduced the documented failure after installing workspace dependencies: `pnpm --filter @fne/web build` succeeded, and the next root `pnpm lint` failed by linting `apps/web/dist/assets/index-*.js` with typed rules.
+- Added a focused Node test (`eslint.config.test.mjs`) that creates a synthetic file under `apps/web/dist/assets`, runs ESLint against `apps` and `packages`, and asserts the generated file is skipped while a real source file is still linted.
+- Narrow fix applied in `eslint.config.mjs`: changed root ignore globs from `dist/**` and `coverage/**` to `**/dist/**` and `**/coverage/**` so nested workspace build output stays outside the typed lint set.
+- Verified both acceptance states locally: `pnpm lint` passes from a clean state and also after `pnpm --filter @fne/web build`.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The root flat ESLint ignore only matched a top-level `dist/`, so `pnpm lint` traversed `apps/web/dist` after a Vite build and applied typed rules to generated JavaScript.
+- What changed: Added a focused ESLint regression test and widened the ignore globs to `**/dist/**` and `**/coverage/**`.
+- Current blocker: none
+- Next exact step: Commit the fix on `codex/issue-151`; open or update the draft PR if supervisor flow requires it next.
+- Verification gap: none for local acceptance; CI has not run yet in this turn.
+- Files touched: `.codex-supervisor/issues/151/issue-journal.md`, `eslint.config.mjs`, `eslint.config.test.mjs`
+- Rollback concern: low; the change only narrows lint traversal away from generated outputs while preserving the `apps` and `packages` source roots.
+- Last focused command: `pnpm lint`
+### Scratchpad
+- Journal rehydration note: this journal was rehydrated on this host because the prior local-only handoff journal was unavailable.
+- Prior host-local handoff text could not be recovered from durable state when recreating the local journal.
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,7 @@ import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   {
-    ignores: ["dist/**", "coverage/**"]
+    ignores: ["**/dist/**", "**/coverage/**"]
   },
   js.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,

--- a/eslint.config.test.mjs
+++ b/eslint.config.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { ESLint } from "eslint";
+
+test("root lint ignores generated web build artifacts but still lints source files", async () => {
+  const generatedFile = path.resolve(
+    "apps/web/dist/assets/eslint-generated-regression.js"
+  );
+
+  await mkdir(path.dirname(generatedFile), { recursive: true });
+  await writeFile(generatedFile, "await Promise.resolve(1);\n");
+
+  try {
+    const eslint = new ESLint({ cwd: process.cwd() });
+    const results = await eslint.lintFiles(["apps", "packages"]);
+    const lintedFiles = new Set(results.map((result) => result.filePath));
+
+    assert.ok(
+      lintedFiles.has(path.resolve("packages/shared/src/content.ts")),
+      "expected root lint to keep checking real TypeScript source files"
+    );
+    assert.ok(
+      !lintedFiles.has(generatedFile),
+      "expected root lint to skip generated apps/web/dist artifacts"
+    );
+  } finally {
+    await rm(generatedFile, { force: true });
+  }
+});


### PR DESCRIPTION
Closes #151
This PR was opened by codex-supervisor.
Latest Codex summary:

Fixed the lint stability issue on `codex/issue-151` with a narrow config change and a focused regression test. The root ESLint flat-config ignore now matches nested workspace build outputs via `**/dist/**` and `**/coverage/**`, and `eslint.config.test.mjs` proves that a synthetic `apps/web/dist` artifact is skipped while real source under `packages/` is still linted.

I reproduced the original failure first, confirmed it was linting `apps/web/dist/assets/index-*.js` after `pnpm --filter @fne/web build`, then verified both acceptance states locally. I also updated the issue journal and committed the fix as `294ca66` (`Fix root lint after web build artifacts`).

Summary: Root lint no longer traverses `apps/web/dist` after a web build; focused regression test added and local acceptance path passes
State hint: implementing
Blocked reason: none
Tests: `pnpm install`; `pnpm --filter @fne/web build`; `pnpm lint`; `node --test eslint.config.test.mjs`; `rm -rf apps/web/dist && pnpm lint`; `pnpm --filter @fne/web build`; `pnpm lint`
Failure signature: eslint-typed-lint-traverses-apps-web-dist
Next action: Open or update the branch PR with commit `294ca66`, then let CI confirm the same build-then-lint path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ESLint to correctly ignore generated output files in nested project directories.

* **Tests**
  * Added regression test to verify generated files are excluded from linting while source files remain checked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->